### PR TITLE
Add multi-editor MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,12 @@ Most tools stop at depth 1 or 2. Lurker reconstructs the entire tree.
 ## Why Not Use Reddit's Official API?
 
 - Requires approval under the Responsible Builder Policy (self-serve keys no longer available)
-- Returns `"kind": "more"` stubs for deep replies that most clients never expand
-- Adds OAuth complexity and token management
+- Adds OAuth complexity and token management for what should be a read-only operation
 - Keys can expire mid-workflow
 
 Reddit still serves full JSON on every public page. Lurker uses that. No signup, no approval wait, no tokens to rotate. Respects Reddit's unauthenticated rate limits (10 req/min) with automatic retry and backoff.
 
-**Note:** Lurker only works with public subreddits and posts. Private and restricted subreddits require authentication, which Lurker deliberately does not support.
+**Note:** Lurker only works with public subreddits and posts. Private and restricted subreddits require authentication, which Lurker does not support at this time.
 
 ## Install
 
@@ -88,7 +87,7 @@ Reddit still serves full JSON on every public page. Lurker uses that. No signup,
 curl -fsSL https://raw.githubusercontent.com/ProgenyAlpha/reddit-lurker/master/install.sh | bash
 ```
 
-No Node. No Go. No nothing. Downloads the binary for your platform and sets up Claude Code.
+No Node. No Go. No nothing. Downloads the binary for your platform and walks you through editor setup. Supports Claude Code, Cursor, Windsurf, VS Code, Cline, and Zed.
 
 ### Node Install
 
@@ -116,16 +115,60 @@ cd reddit-lurker
 
 ---
 
-The installer asks one question: **Skill or MCP?**
+The installer walks you through editor selection and integration mode.
 
-| | Skill | MCP |
-|---|---|---|
-| **How it works** | Claude runs a shell command when needed | A background server gives Claude a native tool |
-| **Context overhead** | ~20 tokens/message (lightweight) | ~438 tokens/message (heavier) |
-| **Caching between calls** | None (fresh process each call) | Yes (server stays warm, 15-min cache) |
-| **Requires Bash permission** | Yes | No |
+### Supported Editors
 
-**Pick Skill** if you want minimal overhead and don't mind Bash prompts. **Pick MCP** if you use Reddit often (cache helps) or run Claude Code with Bash restricted. You can always switch later.
+| Editor | Config location | MCP key |
+|--------|----------------|---------|
+| Claude Code | `~/.claude.json` or `~/.claude/skills/reddit/` | `mcpServers` |
+| Cursor | `~/.cursor/mcp.json` | `mcpServers` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers` |
+| VS Code | `~/.config/Code/User/mcp.json` | `servers` |
+| Cline | VS Code globalStorage (auto-detected) | `mcpServers` |
+| Zed | `~/.config/zed/settings.json` | `context_servers` |
+
+Claude Code also supports a **Skill** mode (~20 tokens overhead vs ~438 for MCP). The installer will ask which you prefer.
+
+### Manual Configuration
+
+If you installed the binary yourself, add lurk to your editor's MCP config:
+
+**Claude Code, Cursor, Windsurf, Cline:**
+```json
+{
+  "mcpServers": {
+    "lurk": {
+      "command": "lurk",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+**VS Code (Copilot Chat):**
+```json
+{
+  "servers": {
+    "lurk": {
+      "command": "lurk",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+**Zed:**
+```json
+{
+  "context_servers": {
+    "lurk": {
+      "command": "lurk",
+      "args": ["serve"]
+    }
+  }
+}
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The installer walks you through editor selection and integration mode.
 | Claude Code | `~/.claude.json` or `~/.claude/skills/reddit/` | `mcpServers` |
 | Cursor | `~/.cursor/mcp.json` | `mcpServers` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers` |
-| VS Code | `~/.config/Code/User/mcp.json` | `servers` |
+| VS Code | `~/.config/Code/User/mcp.json` (Linux) / `~/Library/.../Code/User/mcp.json` (macOS) | `servers` |
 | Cline | VS Code globalStorage (auto-detected) | `mcpServers` |
 | Zed | `~/.config/zed/settings.json` | `context_servers` |
 

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ INSTALL_DIR="$HOME/.local/bin"
 SKILL_DIR="$HOME/.claude/skills/reddit"
 CLAUDE_CONFIG="$HOME/.claude.json"
 VERSION="1.0.0"
+BINARY_INSTALLED=false
 
 # Colors (if terminal supports them)
 RED='\033[0;31m'
@@ -50,16 +51,40 @@ if [ -f "./main.go" ] && [ -f "./go.mod" ]; then
 else
     # Running via curl | bash — download prebuilt binary
     ARCHIVE="lurk-${OS}-${ARCH}.tar.gz"
+    CHECKSUM_FILE="checksums.txt"
     URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+    CHECKSUM_URL="https://github.com/${REPO}/releases/download/v${VERSION}/${CHECKSUM_FILE}"
 
     info "Downloading lurk v${VERSION} for ${OS}/${ARCH}..."
 
     if command -v curl &>/dev/null; then
         curl -fsSL "$URL" -o "$TMPDIR/$ARCHIVE" || fail "Download failed. Is v${VERSION} released? Check https://github.com/${REPO}/releases"
+        curl -fsSL "$CHECKSUM_URL" -o "$TMPDIR/$CHECKSUM_FILE" 2>/dev/null || true
     elif command -v wget &>/dev/null; then
         wget -q "$URL" -O "$TMPDIR/$ARCHIVE" || fail "Download failed. Is v${VERSION} released? Check https://github.com/${REPO}/releases"
+        wget -q "$CHECKSUM_URL" -O "$TMPDIR/$CHECKSUM_FILE" 2>/dev/null || true
     else
         fail "Need curl or wget to download the binary"
+    fi
+
+    # Verify checksum if available
+    if [ -f "$TMPDIR/$CHECKSUM_FILE" ]; then
+        expected=$(grep "$ARCHIVE" "$TMPDIR/$CHECKSUM_FILE" | awk '{print $1}')
+        if [ -n "$expected" ]; then
+            if command -v sha256sum &>/dev/null; then
+                actual=$(sha256sum "$TMPDIR/$ARCHIVE" | awk '{print $1}')
+            elif command -v shasum &>/dev/null; then
+                actual=$(shasum -a 256 "$TMPDIR/$ARCHIVE" | awk '{print $1}')
+            else
+                actual=""
+                warn "No sha256sum or shasum found, skipping checksum verification"
+            fi
+            if [ -n "$actual" ] && [ "$expected" != "$actual" ]; then
+                fail "Checksum verification failed (expected $expected, got $actual)"
+            elif [ -n "$actual" ]; then
+                ok "Checksum verified"
+            fi
+        fi
     fi
 
     tar xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR"
@@ -67,9 +92,12 @@ else
     ok "Downloaded $BINARY"
 fi
 
-# ─── Install binary to PATH ──────────────────────────────────
+# ─── Install binary helpers ──────────────────────────────────
 
-install_binary_to_path() {
+ensure_binary_in_path() {
+    if [ "$BINARY_INSTALLED" = true ]; then
+        return
+    fi
     mkdir -p "$INSTALL_DIR"
     if ! cp "$TMPDIR/$BINARY" "$INSTALL_DIR/$BINARY" 2>/dev/null; then
         warn "Binary is locked (MCP server running?). Copying with new name..."
@@ -84,6 +112,7 @@ install_binary_to_path() {
         warn "$INSTALL_DIR is not in your PATH."
         warn "Add it: export PATH=\"\$HOME/.local/bin:\$PATH\""
     fi
+    BINARY_INSTALLED=true
 }
 
 install_binary_to_skill() {
@@ -116,20 +145,22 @@ editor="${editor:-1}"
 
 choose_mode() {
     local editor_name="$1"
-    echo
-    echo -e "${BOLD}How should ${editor_name} use lurk?${NC}"
-    echo
-    echo "  1) Skill (recommended) — Claude Code only"
-    echo "     Claude runs lurk via Bash when it sees Reddit URLs."
-    echo "     ~20 tokens of context overhead."
-    echo
-    echo "  2) MCP server"
-    echo "     Native tool integration — no Bash needed."
-    echo "     ~438 tokens of context overhead. Pick this for heavy Reddit use."
-    echo
-    read -rp "Choose [1/2] (default: 1): " mode
+    {
+        echo
+        echo -e "${BOLD}How should ${editor_name} use lurk?${NC}"
+        echo
+        echo "  1) Skill (recommended) — Claude Code only"
+        echo "     Claude runs lurk via Bash when it sees Reddit URLs."
+        echo "     ~20 tokens of context overhead."
+        echo
+        echo "  2) MCP server"
+        echo "     Native tool integration — no Bash needed."
+        echo "     ~438 tokens of context overhead. Pick this for heavy Reddit use."
+        echo
+    } >&2
+    read -rp "Choose [1/2] (default: 1): " mode </dev/tty
     mode="${mode:-1}"
-    echo "$mode"
+    printf '%s' "$mode"
 }
 
 # ─── Skill install (Claude Code only) ────────────────────────
@@ -196,12 +227,19 @@ SKILLEOF
 # $1 = config file path
 # $2 = top-level key (mcpServers, servers, context_servers)
 # $3 = lurk binary path
-# $4 = extra fields (optional, for Cline)
+# $4 = extra JSON fields (optional, e.g. '"disabled": false')
 write_mcp_config() {
     local config_file="$1"
     local top_key="$2"
     local lurk_path="$3"
     local extra="${4:-}"
+
+    local extra_jq=""
+    local extra_py=""
+    if [ -n "$extra" ]; then
+        extra_jq=", ${extra}"
+        extra_py=", ${extra}"
+    fi
 
     if [ ! -f "$config_file" ]; then
         mkdir -p "$(dirname "$config_file")"
@@ -211,7 +249,8 @@ write_mcp_config() {
   "$top_key": {
     "lurk": {
       "command": "$lurk_path",
-      "args": ["serve"]${extra}
+      "args": ["serve"],
+      ${extra}
     }
   }
 }
@@ -236,9 +275,10 @@ MCPEOF
     if command -v jq &>/dev/null; then
         local tmp
         tmp=$(mktemp)
-        if [ "$top_key" = "context_servers" ]; then
+        if [ -n "$extra" ]; then
+            # Build the full object with extra fields using jq
             jq --arg path "$lurk_path" --arg key "$top_key" \
-                '.[$key].lurk = {"command": $path, "args": ["serve"]}' \
+                '.[$key].lurk = (.[$key].lurk // {}) * {"command": $path, "args": ["serve"]} * {'"$extra"'}' \
                 "$config_file" > "$tmp"
         else
             jq --arg path "$lurk_path" --arg key "$top_key" \
@@ -252,10 +292,9 @@ MCPEOF
 import json
 with open("$config_file") as f:
     config = json.load(f)
-config.setdefault("$top_key", {})["lurk"] = {
-    "command": "$lurk_path",
-    "args": ["serve"]
-}
+entry = {"command": "$lurk_path", "args": ["serve"]}
+$([ -n "$extra" ] && echo "entry.update({$extra_py})")
+config.setdefault("$top_key", {})["lurk"] = entry
 with open("$config_file", "w") as f:
     json.dump(config, f, indent=2)
 PYEOF
@@ -286,39 +325,34 @@ install_claude() {
     esac
 }
 
-install_cursor() {
-    local config_dir="$HOME/.cursor"
-    local config_file="$config_dir/mcp.json"
+configure_cursor() {
+    local config_file="$HOME/.cursor/mcp.json"
     info "Configuring Cursor MCP server"
-    install_binary_to_path
     write_mcp_config "$config_file" "mcpServers" "$INSTALL_DIR/$BINARY"
     ok "Cursor configured (global)"
     warn "Restart Cursor to load the new MCP server."
     warn "MCP tools are available in Agent mode and Composer, not regular chat."
 }
 
-install_windsurf() {
-    local config_dir="$HOME/.codeium/windsurf"
-    local config_file="$config_dir/mcp_config.json"
+configure_windsurf() {
+    local config_file="$HOME/.codeium/windsurf/mcp_config.json"
     info "Configuring Windsurf MCP server"
-    install_binary_to_path
     write_mcp_config "$config_file" "mcpServers" "$INSTALL_DIR/$BINARY"
     ok "Windsurf configured"
     warn "Restart Windsurf to load the new MCP server."
 }
 
-install_vscode() {
-    local config_file="$HOME/.vscode/mcp.json"
+configure_vscode() {
+    local config_file
 
     # VS Code user-level MCP config location varies by OS
     if [ "$OS" = "darwin" ]; then
         config_file="$HOME/Library/Application Support/Code/User/mcp.json"
-    elif [ "$OS" = "linux" ]; then
+    else
         config_file="$HOME/.config/Code/User/mcp.json"
     fi
 
     info "Configuring VS Code (Copilot Chat) MCP server"
-    install_binary_to_path
 
     # VS Code uses "servers" not "mcpServers"
     write_mcp_config "$config_file" "servers" "$INSTALL_DIR/$BINARY"
@@ -327,7 +361,7 @@ install_vscode() {
     warn "Requires VS Code 1.99+ and Copilot Chat in Agent mode."
 }
 
-install_cline() {
+configure_cline() {
     local config_file
 
     if [ "$OS" = "darwin" ]; then
@@ -339,58 +373,24 @@ install_cline() {
     fi
 
     info "Configuring Cline MCP server"
-    install_binary_to_path
-    write_mcp_config "$config_file" "mcpServers" "$INSTALL_DIR/$BINARY" ',
-      "disabled": false,
-      "alwaysAllow": []'
+    write_mcp_config "$config_file" "mcpServers" "$INSTALL_DIR/$BINARY" '"disabled": false, "alwaysAllow": []'
     ok "Cline configured"
     warn "Restart VS Code to load the new MCP server."
 }
 
-install_zed() {
+configure_zed() {
     local config_file="$HOME/.config/zed/settings.json"
     info "Configuring Zed MCP server"
-    install_binary_to_path
-
-    if [ ! -f "$config_file" ]; then
-        mkdir -p "$(dirname "$config_file")"
-        cat > "$config_file" << MCPEOF
-{
-  "context_servers": {
-    "lurk": {
-      "command": "$INSTALL_DIR/$BINARY",
-      "args": ["serve"]
-    }
-  }
-}
-MCPEOF
-        ok "Created $config_file"
-    elif command -v jq &>/dev/null; then
-        local tmp
-        tmp=$(mktemp)
-        jq --arg path "$INSTALL_DIR/$BINARY" \
-            '.context_servers.lurk = {"command": $path, "args": ["serve"]}' \
-            "$config_file" > "$tmp"
-        mv "$tmp" "$config_file"
-        ok "Updated $config_file"
-    elif command -v python3 &>/dev/null; then
-        python3 << PYEOF
-import json
-with open("$config_file") as f:
-    config = json.load(f)
-config.setdefault("context_servers", {})["lurk"] = {
-    "command": "$INSTALL_DIR/$BINARY",
-    "args": ["serve"]
-}
-with open("$config_file", "w") as f:
-    json.dump(config, f, indent=2)
-PYEOF
-        ok "Updated $config_file"
-    else
-        warn "Neither jq nor python3 found. Add lurk manually to $config_file under context_servers."
-    fi
+    write_mcp_config "$config_file" "context_servers" "$INSTALL_DIR/$BINARY"
     warn "Restart Zed to load the new MCP server."
 }
+
+# Standalone editor installers (binary + config)
+install_cursor()   { ensure_binary_in_path; configure_cursor; }
+install_windsurf() { ensure_binary_in_path; configure_windsurf; }
+install_vscode()   { ensure_binary_in_path; configure_vscode; }
+install_cline()    { ensure_binary_in_path; configure_cline; }
+install_zed()      { ensure_binary_in_path; configure_zed; }
 
 install_all() {
     echo
@@ -400,19 +400,21 @@ install_all() {
     # Claude Code gets the skill/MCP choice
     install_claude
 
-    # Everything else gets MCP via binary in PATH
-    install_cursor
-    install_windsurf
-    install_vscode
-    install_cline
-    install_zed
+    # Install binary once for all other editors
+    ensure_binary_in_path
+
+    # Configure each editor
+    configure_cursor
+    configure_windsurf
+    configure_vscode
+    configure_cline
+    configure_zed
 }
 
 install_binary_only() {
     info "Installing binary only"
-    install_binary_to_path
+    ensure_binary_in_path
     echo
-    ok "Binary installed to $INSTALL_DIR/$BINARY"
     echo "Configure your editor manually. See README for config examples."
 }
 

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO="ProgenyAlpha/reddit-lurker"
 BINARY="lurk"
+INSTALL_DIR="$HOME/.local/bin"
 SKILL_DIR="$HOME/.claude/skills/reddit"
 CLAUDE_CONFIG="$HOME/.claude.json"
 VERSION="1.0.0"
@@ -21,7 +22,7 @@ warn()  { echo -e "${YELLOW}!${NC} $*"; }
 fail()  { echo -e "${RED}✗${NC} $*"; exit 1; }
 
 echo -e "${BOLD}reddit-lurker${NC} v${VERSION}"
-echo "Reddit reader for Claude Code"
+echo "Reddit reader for LLM code editors"
 echo
 
 # ─── Detect platform ───────────────────────────────────────────
@@ -66,28 +67,27 @@ else
     ok "Downloaded $BINARY"
 fi
 
-# ─── Choose install mode ──────────────────────────────────────
+# ─── Install binary to PATH ──────────────────────────────────
 
-echo
-echo -e "${BOLD}How should Claude Code use lurk?${NC}"
-echo
-echo "  1) Skill (recommended)"
-echo "     Claude runs lurk via Bash when it sees Reddit URLs."
-echo "     ~20 tokens of context overhead."
-echo
-echo "  2) MCP server"
-echo "     Claude gets lurk as a native tool — no Bash needed."
-echo "     ~438 tokens of context overhead. Pick this for heavy Reddit use."
-echo
-read -rp "Choose [1/2] (default: 1): " mode
-mode="${mode:-1}"
+install_binary_to_path() {
+    mkdir -p "$INSTALL_DIR"
+    if ! cp "$TMPDIR/$BINARY" "$INSTALL_DIR/$BINARY" 2>/dev/null; then
+        warn "Binary is locked (MCP server running?). Copying with new name..."
+        cp "$TMPDIR/$BINARY" "$INSTALL_DIR/${BINARY}.new"
+        mv "$INSTALL_DIR/${BINARY}.new" "$INSTALL_DIR/$BINARY"
+    fi
+    chmod +x "$INSTALL_DIR/$BINARY"
+    ok "Binary installed to $INSTALL_DIR/$BINARY"
 
-# ─── Install functions ─────────────────────────────────────────
+    # Check if ~/.local/bin is in PATH
+    if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+        warn "$INSTALL_DIR is not in your PATH."
+        warn "Add it: export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
+}
 
-install_binary() {
+install_binary_to_skill() {
     mkdir -p "$SKILL_DIR"
-
-    # Handle locked binary (MCP server may be holding it)
     if ! cp "$TMPDIR/$BINARY" "$SKILL_DIR/$BINARY" 2>/dev/null; then
         warn "Binary is locked (MCP server running?). Copying with new name..."
         cp "$TMPDIR/$BINARY" "$SKILL_DIR/${BINARY}.new"
@@ -96,15 +96,51 @@ install_binary() {
     chmod +x "$SKILL_DIR/$BINARY"
 }
 
+# ─── Choose editor ────────────────────────────────────────────
+
+echo -e "${BOLD}Which editor(s) should lurk integrate with?${NC}"
+echo
+echo "  1) Claude Code"
+echo "  2) Cursor"
+echo "  3) Windsurf"
+echo "  4) VS Code (Copilot Chat)"
+echo "  5) Cline"
+echo "  6) Zed"
+echo "  7) All of the above"
+echo "  8) Just install the binary (I'll configure it myself)"
+echo
+read -rp "Choose [1-8] (default: 1): " editor
+editor="${editor:-1}"
+
+# ─── Choose mode (for editors that support both) ─────────────
+
+choose_mode() {
+    local editor_name="$1"
+    echo
+    echo -e "${BOLD}How should ${editor_name} use lurk?${NC}"
+    echo
+    echo "  1) Skill (recommended) — Claude Code only"
+    echo "     Claude runs lurk via Bash when it sees Reddit URLs."
+    echo "     ~20 tokens of context overhead."
+    echo
+    echo "  2) MCP server"
+    echo "     Native tool integration — no Bash needed."
+    echo "     ~438 tokens of context overhead. Pick this for heavy Reddit use."
+    echo
+    read -rp "Choose [1/2] (default: 1): " mode
+    mode="${mode:-1}"
+    echo "$mode"
+}
+
+# ─── Skill install (Claude Code only) ────────────────────────
+
 install_skill() {
     info "Installing skill to $SKILL_DIR"
 
-    # Remove old lurk skill if it exists under different name
     [ -d "$HOME/.claude/skills/lurk" ] && rm -rf "$HOME/.claude/skills/lurk"
 
-    install_binary
+    install_binary_to_skill
 
-    # Write SKILL.md
     cat > "$SKILL_DIR/SKILL.md" << 'SKILLEOF'
 # Lurk — Reddit Reader
 
@@ -154,72 +190,245 @@ SKILLEOF
     ok "Skill installed"
 }
 
-install_mcp() {
-    local lurk_path="$SKILL_DIR/$BINARY"
-    info "Configuring MCP server"
+# ─── MCP config helpers ──────────────────────────────────────
 
-    install_binary
+# Write or merge JSON MCP config into a file
+# $1 = config file path
+# $2 = top-level key (mcpServers, servers, context_servers)
+# $3 = lurk binary path
+# $4 = extra fields (optional, for Cline)
+write_mcp_config() {
+    local config_file="$1"
+    local top_key="$2"
+    local lurk_path="$3"
+    local extra="${4:-}"
 
-    # Edit claude config
-    if [ ! -f "$CLAUDE_CONFIG" ]; then
-        cat > "$CLAUDE_CONFIG" << MCPEOF
+    if [ ! -f "$config_file" ]; then
+        mkdir -p "$(dirname "$config_file")"
+        if [ -n "$extra" ]; then
+            cat > "$config_file" << MCPEOF
 {
-  "mcpServers": {
+  "$top_key": {
     "lurk": {
-      "type": "stdio",
+      "command": "$lurk_path",
+      "args": ["serve"]${extra}
+    }
+  }
+}
+MCPEOF
+        else
+            cat > "$config_file" << MCPEOF
+{
+  "$top_key": {
+    "lurk": {
       "command": "$lurk_path",
       "args": ["serve"]
     }
   }
 }
 MCPEOF
-        ok "Created $CLAUDE_CONFIG with lurk MCP server"
+        fi
+        ok "Created $config_file"
         return
     fi
 
-    # Check if already configured
-    if grep -q '"lurk"' "$CLAUDE_CONFIG" 2>/dev/null; then
-        info "Updating existing lurk entry in $CLAUDE_CONFIG"
-    fi
-
-    # Use jq if available, fall back to python3
+    # File exists — merge using jq or python3
     if command -v jq &>/dev/null; then
         local tmp
         tmp=$(mktemp)
-        jq --arg path "$lurk_path" '.mcpServers.lurk = {"type": "stdio", "command": $path, "args": ["serve"]}' "$CLAUDE_CONFIG" > "$tmp"
-        mv "$tmp" "$CLAUDE_CONFIG"
+        if [ "$top_key" = "context_servers" ]; then
+            jq --arg path "$lurk_path" --arg key "$top_key" \
+                '.[$key].lurk = {"command": $path, "args": ["serve"]}' \
+                "$config_file" > "$tmp"
+        else
+            jq --arg path "$lurk_path" --arg key "$top_key" \
+                '.[$key].lurk = {"command": $path, "args": ["serve"]}' \
+                "$config_file" > "$tmp"
+        fi
+        mv "$tmp" "$config_file"
+        ok "Updated $config_file"
     elif command -v python3 &>/dev/null; then
         python3 << PYEOF
 import json
-with open("$CLAUDE_CONFIG") as f:
+with open("$config_file") as f:
     config = json.load(f)
-config.setdefault("mcpServers", {})["lurk"] = {
-    "type": "stdio",
+config.setdefault("$top_key", {})["lurk"] = {
     "command": "$lurk_path",
     "args": ["serve"]
 }
-with open("$CLAUDE_CONFIG", "w") as f:
+with open("$config_file", "w") as f:
     json.dump(config, f, indent=2)
 PYEOF
+        ok "Updated $config_file"
     else
-        warn "Neither jq nor python3 found. Add lurk MCP server manually:"
-        echo
-        echo "  Add to $CLAUDE_CONFIG under mcpServers:"
-        echo "    \"lurk\": {\"type\": \"stdio\", \"command\": \"$lurk_path\", \"args\": [\"serve\"]}"
-        return
+        warn "Neither jq nor python3 found. Add lurk manually to $config_file:"
+        echo "  Under \"$top_key\": {\"lurk\": {\"command\": \"$lurk_path\", \"args\": [\"serve\"]}}"
+    fi
+}
+
+# ─── Editor-specific installers ──────────────────────────────
+
+install_claude_mcp() {
+    local lurk_path="$SKILL_DIR/$BINARY"
+    info "Configuring Claude Code MCP server"
+    install_binary_to_skill
+    write_mcp_config "$CLAUDE_CONFIG" "mcpServers" "$lurk_path"
+    warn "Restart Claude Code to load the new MCP server."
+}
+
+install_claude() {
+    local mode
+    mode=$(choose_mode "Claude Code")
+    case "$mode" in
+        1) install_skill ;;
+        2) install_claude_mcp ;;
+        *) fail "Invalid choice: $mode" ;;
+    esac
+}
+
+install_cursor() {
+    local config_dir="$HOME/.cursor"
+    local config_file="$config_dir/mcp.json"
+    info "Configuring Cursor MCP server"
+    install_binary_to_path
+    write_mcp_config "$config_file" "mcpServers" "$INSTALL_DIR/$BINARY"
+    ok "Cursor configured (global)"
+    warn "Restart Cursor to load the new MCP server."
+    warn "MCP tools are available in Agent mode and Composer, not regular chat."
+}
+
+install_windsurf() {
+    local config_dir="$HOME/.codeium/windsurf"
+    local config_file="$config_dir/mcp_config.json"
+    info "Configuring Windsurf MCP server"
+    install_binary_to_path
+    write_mcp_config "$config_file" "mcpServers" "$INSTALL_DIR/$BINARY"
+    ok "Windsurf configured"
+    warn "Restart Windsurf to load the new MCP server."
+}
+
+install_vscode() {
+    local config_file="$HOME/.vscode/mcp.json"
+
+    # VS Code user-level MCP config location varies by OS
+    if [ "$OS" = "darwin" ]; then
+        config_file="$HOME/Library/Application Support/Code/User/mcp.json"
+    elif [ "$OS" = "linux" ]; then
+        config_file="$HOME/.config/Code/User/mcp.json"
     fi
 
-    ok "MCP server configured in $CLAUDE_CONFIG"
-    warn "Restart Claude Code to load the new MCP server."
+    info "Configuring VS Code (Copilot Chat) MCP server"
+    install_binary_to_path
+
+    # VS Code uses "servers" not "mcpServers"
+    write_mcp_config "$config_file" "servers" "$INSTALL_DIR/$BINARY"
+    ok "VS Code configured"
+    warn "Restart VS Code to load the new MCP server."
+    warn "Requires VS Code 1.99+ and Copilot Chat in Agent mode."
+}
+
+install_cline() {
+    local config_file
+
+    if [ "$OS" = "darwin" ]; then
+        config_file="$HOME/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+    elif [ "$OS" = "linux" ]; then
+        config_file="$HOME/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+    else
+        fail "Cline config path unknown for $OS. Configure manually via the Cline UI."
+    fi
+
+    info "Configuring Cline MCP server"
+    install_binary_to_path
+    write_mcp_config "$config_file" "mcpServers" "$INSTALL_DIR/$BINARY" ',
+      "disabled": false,
+      "alwaysAllow": []'
+    ok "Cline configured"
+    warn "Restart VS Code to load the new MCP server."
+}
+
+install_zed() {
+    local config_file="$HOME/.config/zed/settings.json"
+    info "Configuring Zed MCP server"
+    install_binary_to_path
+
+    if [ ! -f "$config_file" ]; then
+        mkdir -p "$(dirname "$config_file")"
+        cat > "$config_file" << MCPEOF
+{
+  "context_servers": {
+    "lurk": {
+      "command": "$INSTALL_DIR/$BINARY",
+      "args": ["serve"]
+    }
+  }
+}
+MCPEOF
+        ok "Created $config_file"
+    elif command -v jq &>/dev/null; then
+        local tmp
+        tmp=$(mktemp)
+        jq --arg path "$INSTALL_DIR/$BINARY" \
+            '.context_servers.lurk = {"command": $path, "args": ["serve"]}' \
+            "$config_file" > "$tmp"
+        mv "$tmp" "$config_file"
+        ok "Updated $config_file"
+    elif command -v python3 &>/dev/null; then
+        python3 << PYEOF
+import json
+with open("$config_file") as f:
+    config = json.load(f)
+config.setdefault("context_servers", {})["lurk"] = {
+    "command": "$INSTALL_DIR/$BINARY",
+    "args": ["serve"]
+}
+with open("$config_file", "w") as f:
+    json.dump(config, f, indent=2)
+PYEOF
+        ok "Updated $config_file"
+    else
+        warn "Neither jq nor python3 found. Add lurk manually to $config_file under context_servers."
+    fi
+    warn "Restart Zed to load the new MCP server."
+}
+
+install_all() {
+    echo
+    info "Installing for all supported editors..."
+    echo
+
+    # Claude Code gets the skill/MCP choice
+    install_claude
+
+    # Everything else gets MCP via binary in PATH
+    install_cursor
+    install_windsurf
+    install_vscode
+    install_cline
+    install_zed
+}
+
+install_binary_only() {
+    info "Installing binary only"
+    install_binary_to_path
+    echo
+    ok "Binary installed to $INSTALL_DIR/$BINARY"
+    echo "Configure your editor manually. See README for config examples."
 }
 
 # ─── Execute ───────────────────────────────────────────────────
 
-case "$mode" in
-    1) install_skill ;;
-    2) install_mcp ;;
-    *) fail "Invalid choice: $mode" ;;
+case "$editor" in
+    1) install_claude ;;
+    2) install_cursor ;;
+    3) install_windsurf ;;
+    4) install_vscode ;;
+    5) install_cline ;;
+    6) install_zed ;;
+    7) install_all ;;
+    8) install_binary_only ;;
+    *) fail "Invalid choice: $editor" ;;
 esac
 
 echo
-ok "Done! Start a new Claude Code session and try pasting a Reddit URL."
+ok "Done! Restart your editor and try pasting a Reddit URL."


### PR DESCRIPTION
## Summary

- Installer now supports 6 editors: Claude Code, Cursor, Windsurf, VS Code (Copilot Chat), Cline, and Zed
- Each editor gets the correct config path and JSON key (`mcpServers`, `servers`, or `context_servers`)
- Binary installs to `~/.local/bin` for non-Claude editors, keeping it in PATH
- README updated with supported editors table and manual config examples for each
- Changed private sub note from "does not support" to "does not support at this time"
- Removed `kind: more` from API comparison (that's a client-side issue, not Reddit's API)

## Test plan

- [ ] Run `./install.sh` and select each editor option (1-8)
- [ ] Verify config files are created/updated correctly for each editor
- [ ] Verify binary is placed in correct location per mode
- [ ] Test "All of the above" option
- [ ] Test "binary only" option
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-editor install modes and per-editor automated setup (Claude Code, Cursor, Windsurf, VS Code, Cline, Zed) plus a binary-only option.
  * Installer now manages binary installation, verifies checksums when available, and prompts to restart the editor.

* **Documentation**
  * Expanded installation guide with editor-focused walkthroughs, explicit per-editor configuration examples/JSON, and a supported-editors reference table.
  * Clarified OAuth messaging and softened private subreddit wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->