### PR TITLE
Add Windows support with PowerShell installer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
@@ -17,11 +18,15 @@ builds:
 archives:
   - format: tar.gz
     name_template: "lurk-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
     files:
       - LICENSE
       - README.md
       - skill/SKILL.md
       - install.sh
+      - install.ps1
 
 checksum:
   name_template: checksums.txt

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: $(BINARY)
 $(BINARY): $(GOFILES)
 	go build $(LDFLAGS) -o $(BINARY) .
 
-all: build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64
+all: build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64 build-windows-amd64 build-windows-arm64
 
 build-linux-amd64:
 	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o dist/$(BINARY)-linux-amd64 .
@@ -23,6 +23,12 @@ build-darwin-amd64:
 
 build-darwin-arm64:
 	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o dist/$(BINARY)-darwin-arm64 .
+
+build-windows-amd64:
+	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o dist/$(BINARY)-windows-amd64.exe .
+
+build-windows-arm64:
+	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o dist/$(BINARY)-windows-arm64.exe .
 
 install: build
 	cp $(BINARY) $(HOME)/.local/bin/$(BINARY)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,15 @@ Reddit still serves full JSON on every public page. Lurker uses that. No signup,
 curl -fsSL https://raw.githubusercontent.com/ProgenyAlpha/reddit-lurker/master/install.sh | bash
 ```
 
-No Node. No Go. No nothing. Downloads the binary for your platform and walks you through editor setup. Supports Claude Code, Cursor, Windsurf, VS Code, Cline, and Zed.
+No Node. No Go. No nothing. Downloads the binary for your platform and walks you through editor setup. Supports Claude Code, Cursor, Windsurf, VS Code, Cline, and Zed. Works on Linux and macOS.
+
+### Windows Install
+
+```powershell
+irm https://raw.githubusercontent.com/ProgenyAlpha/reddit-lurker/master/install.ps1 | iex
+```
+
+Same interactive setup, installs to `%LOCALAPPDATA%\lurk` and adds it to your PATH.
 
 ### Node Install
 

--- a/install.ps1
+++ b/install.ps1
@@ -194,7 +194,7 @@ function Install-Cline {
 }
 
 function Install-Zed {
-    $config = Join-Path $env:USERPROFILE ".config\zed\settings.json"
+    $config = Join-Path $env:APPDATA "Zed\settings.json"
     Write-Info "Configuring Zed MCP server"
     Write-McpConfig -ConfigFile $config -TopKey "context_servers" -LurkPath $BinaryPath
     Write-Warn "Restart Zed to load the new MCP server."

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,240 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Install reddit-lurker (lurk) on Windows.
+.DESCRIPTION
+    Downloads the latest release binary from GitHub and configures
+    editor MCP integration. Supports Claude Code, Cursor, Windsurf,
+    VS Code, Cline, and Zed.
+.EXAMPLE
+    irm https://raw.githubusercontent.com/ProgenyAlpha/reddit-lurker/master/install.ps1 | iex
+#>
+
+$ErrorActionPreference = "Stop"
+$Repo = "ProgenyAlpha/reddit-lurker"
+$Binary = "lurk.exe"
+$InstallDir = Join-Path $env:LOCALAPPDATA "lurk"
+$BinaryPath = Join-Path $InstallDir $Binary
+
+# ─── Helpers ──────────────────────────────────────────────────
+
+function Write-Info  { param($msg) Write-Host "→ $msg" -ForegroundColor Cyan }
+function Write-Ok    { param($msg) Write-Host "✓ $msg" -ForegroundColor Green }
+function Write-Warn  { param($msg) Write-Host "! $msg" -ForegroundColor Yellow }
+function Write-Fail  { param($msg) Write-Host "✗ $msg" -ForegroundColor Red; exit 1 }
+
+# ─── Detect version ──────────────────────────────────────────
+
+Write-Info "Fetching latest version..."
+try {
+    $release = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest"
+    $Version = $release.tag_name -replace '^v', ''
+} catch {
+    Write-Fail "Could not determine latest version. Check https://github.com/$Repo/releases"
+}
+
+Write-Host ""
+Write-Host "reddit-lurker v$Version" -ForegroundColor White -NoNewline
+Write-Host ""
+Write-Host "Reddit reader for LLM code editors"
+Write-Host ""
+
+# ─── Detect architecture ─────────────────────────────────────
+
+$Arch = if ([Environment]::Is64BitOperatingSystem) {
+    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
+} else {
+    Write-Fail "32-bit Windows is not supported"
+}
+Write-Info "Platform: windows/$Arch"
+
+# ─── Download binary ─────────────────────────────────────────
+
+$Archive = "lurk-windows-$Arch.zip"
+$Url = "https://github.com/$Repo/releases/download/v$Version/$Archive"
+$ChecksumUrl = "https://github.com/$Repo/releases/download/v$Version/checksums.txt"
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "lurk-install-$(Get-Random)"
+New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
+
+try {
+    Write-Info "Downloading lurk v$Version for windows/$Arch..."
+    Invoke-WebRequest -Uri $Url -OutFile (Join-Path $TmpDir $Archive) -UseBasicParsing
+
+    # Verify checksum if available
+    try {
+        $checksums = Invoke-WebRequest -Uri $ChecksumUrl -UseBasicParsing
+        $expected = ($checksums.Content -split "`n" | Where-Object { $_ -match $Archive } | ForEach-Object { ($_ -split '\s+')[0] })
+        if ($expected) {
+            $actual = (Get-FileHash (Join-Path $TmpDir $Archive) -Algorithm SHA256).Hash.ToLower()
+            if ($actual -ne $expected.ToLower()) {
+                Write-Fail "Checksum verification failed"
+            }
+            Write-Ok "Checksum verified"
+        }
+    } catch {
+        # Checksum file not available, skip
+    }
+
+    Expand-Archive -Path (Join-Path $TmpDir $Archive) -DestinationPath $TmpDir -Force
+    Write-Ok "Downloaded lurk"
+} catch {
+    Write-Fail "Download failed. Is v$Version released? Check https://github.com/$Repo/releases"
+}
+
+# ─── Install binary ──────────────────────────────────────────
+
+New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+Copy-Item (Join-Path $TmpDir $Binary) $BinaryPath -Force
+Write-Ok "Binary installed to $BinaryPath"
+
+# Add to PATH if not already there
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
+    $env:Path = "$env:Path;$InstallDir"
+    Write-Ok "Added $InstallDir to PATH"
+    Write-Warn "Restart your terminal for PATH changes to take effect."
+} else {
+    Write-Ok "$InstallDir already in PATH"
+}
+
+# ─── Choose editor ────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "Which editor(s) should lurk integrate with?" -ForegroundColor White
+Write-Host ""
+Write-Host "  1) Claude Code"
+Write-Host "  2) Cursor"
+Write-Host "  3) Windsurf"
+Write-Host "  4) VS Code (Copilot Chat)"
+Write-Host "  5) Cline"
+Write-Host "  6) Zed"
+Write-Host "  7) All of the above"
+Write-Host "  8) Just install the binary (I'll configure it myself)"
+Write-Host ""
+$choice = Read-Host "Choose [1-8, comma-separated] (default: 1)"
+if ([string]::IsNullOrWhiteSpace($choice)) { $choice = "1" }
+
+$editors = $choice -split ',' | ForEach-Object { $_.Trim() }
+foreach ($e in $editors) {
+    if ($e -notmatch '^[1-8]$') { Write-Fail "Invalid choice: $e" }
+}
+
+# ─── MCP config helper ───────────────────────────────────────
+
+function Write-McpConfig {
+    param(
+        [string]$ConfigFile,
+        [string]$TopKey,
+        [string]$LurkPath,
+        [hashtable]$Extra = @{}
+    )
+
+    $lurkEntry = @{
+        command = $LurkPath
+        args = @("serve")
+    }
+    foreach ($k in $Extra.Keys) { $lurkEntry[$k] = $Extra[$k] }
+
+    $dir = Split-Path $ConfigFile -Parent
+    if (!(Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+
+    if (Test-Path $ConfigFile) {
+        $config = Get-Content $ConfigFile -Raw | ConvertFrom-Json
+        # Ensure top-level key exists
+        if (-not $config.$TopKey) {
+            $config | Add-Member -NotePropertyName $TopKey -NotePropertyValue ([PSCustomObject]@{}) -Force
+        }
+        $config.$TopKey | Add-Member -NotePropertyName "lurk" -NotePropertyValue ([PSCustomObject]$lurkEntry) -Force
+        $config | ConvertTo-Json -Depth 10 | Set-Content $ConfigFile -Encoding UTF8
+        Write-Ok "Updated $ConfigFile"
+    } else {
+        $config = @{ $TopKey = @{ lurk = $lurkEntry } }
+        $config | ConvertTo-Json -Depth 10 | Set-Content $ConfigFile -Encoding UTF8
+        Write-Ok "Created $ConfigFile"
+    }
+}
+
+# ─── Editor installers ───────────────────────────────────────
+
+function Install-Claude {
+    $claudeConfig = Join-Path $env:USERPROFILE ".claude.json"
+    Write-Info "Configuring Claude Code MCP server"
+    Write-McpConfig -ConfigFile $claudeConfig -TopKey "mcpServers" -LurkPath $BinaryPath
+    Write-Warn "Restart Claude Code to load the new MCP server."
+}
+
+function Install-Cursor {
+    $config = Join-Path $env:USERPROFILE ".cursor\mcp.json"
+    Write-Info "Configuring Cursor MCP server"
+    Write-McpConfig -ConfigFile $config -TopKey "mcpServers" -LurkPath $BinaryPath
+    Write-Warn "Restart Cursor to load the new MCP server."
+}
+
+function Install-Windsurf {
+    $config = Join-Path $env:USERPROFILE ".codeium\windsurf\mcp_config.json"
+    Write-Info "Configuring Windsurf MCP server"
+    Write-McpConfig -ConfigFile $config -TopKey "mcpServers" -LurkPath $BinaryPath
+    Write-Warn "Restart Windsurf to load the new MCP server."
+}
+
+function Install-VsCode {
+    $config = Join-Path $env:APPDATA "Code\User\mcp.json"
+    Write-Info "Configuring VS Code (Copilot Chat) MCP server"
+    Write-McpConfig -ConfigFile $config -TopKey "servers" -LurkPath $BinaryPath
+    Write-Warn "Restart VS Code to load the new MCP server."
+    Write-Warn "Requires VS Code 1.99+ and Copilot Chat in Agent mode."
+}
+
+function Install-Cline {
+    $config = Join-Path $env:APPDATA "Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json"
+    Write-Info "Configuring Cline MCP server"
+    Write-McpConfig -ConfigFile $config -TopKey "mcpServers" -LurkPath $BinaryPath -Extra @{ disabled = $false; alwaysAllow = @() }
+    Write-Warn "Restart VS Code to load the new MCP server."
+}
+
+function Install-Zed {
+    $config = Join-Path $env:USERPROFILE ".config\zed\settings.json"
+    Write-Info "Configuring Zed MCP server"
+    Write-McpConfig -ConfigFile $config -TopKey "context_servers" -LurkPath $BinaryPath
+    Write-Warn "Restart Zed to load the new MCP server."
+}
+
+function Install-All {
+    Write-Host ""
+    Write-Info "Installing for all supported editors..."
+    Write-Host ""
+    Install-Claude
+    Install-Cursor
+    Install-Windsurf
+    Install-VsCode
+    Install-Cline
+    Install-Zed
+}
+
+function Install-BinaryOnly {
+    Write-Info "Binary-only install"
+    Write-Host "Configure your editor manually. See README for config examples."
+}
+
+# ─── Execute ──────────────────────────────────────────────────
+
+foreach ($e in $editors) {
+    switch ($e) {
+        "1" { Install-Claude }
+        "2" { Install-Cursor }
+        "3" { Install-Windsurf }
+        "4" { Install-VsCode }
+        "5" { Install-Cline }
+        "6" { Install-Zed }
+        "7" { Install-All }
+        "8" { Install-BinaryOnly }
+    }
+}
+
+# ─── Cleanup ──────────────────────────────────────────────────
+
+Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host ""
+Write-Ok "Done! Restart your editor and try pasting a Reddit URL."

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
     Install reddit-lurker (lurk) on Windows.
@@ -71,8 +71,10 @@ try {
             }
             Write-Ok "Checksum verified"
         }
+    } catch [System.Net.WebException] {
+        # Checksum file not available for this release, skip verification
     } catch {
-        # Checksum file not available, skip
+        Write-Warn "Checksum verification skipped: $($_.Exception.Message)"
     }
 
     Expand-Archive -Path (Join-Path $TmpDir $Archive) -DestinationPath $TmpDir -Force
@@ -115,7 +117,9 @@ Write-Host ""
 $choice = Read-Host "Choose [1-8, comma-separated] (default: 1)"
 if ([string]::IsNullOrWhiteSpace($choice)) { $choice = "1" }
 
-$editors = $choice -split ',' | ForEach-Object { $_.Trim() }
+$editors = $choice -split ',' | ForEach-Object { $_.Trim() } | Select-Object -Unique
+if ($editors -contains '7') { $editors = @('7') }
+if ($editors -contains '8' -and $editors.Count -gt 1) { $editors = $editors | Where-Object { $_ -ne '8' } }
 foreach ($e in $editors) {
     if ($e -notmatch '^[1-8]$') { Write-Fail "Invalid choice: $e" }
 }


### PR DESCRIPTION
## Summary

- Windows added to goreleaser build matrix (amd64 + arm64, zip format)
- New `install.ps1` PowerShell installer with same multi-editor support as bash
- Installs binary to `%LOCALAPPDATA%\lurk`, adds to user PATH automatically
- Supports same comma-separated multi-select for editors (1,3,5 etc.)
- Windows cross-compile targets added to Makefile
- README updated with Windows install command

## Test plan

- [ ] `GOOS=windows go build` compiles successfully
- [ ] PowerShell installer downloads correct binary for platform
- [ ] Editor config files created at correct Windows paths
- [ ] PATH modification works and persists across terminal sessions
- [ ] Multi-select editor choice works (e.g., "1,4")
- [ ] Binary-only install option works
- [ ] `irm ... | iex` pipe install works in PowerShell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Full Windows platform support with native PowerShell installer providing automated binary installation and environment setup.
  * Interactive editor integration selection during installation for Claude, Cursor, Windsurf, VS Code, Cline, and Zed with automatic configuration.

* **Documentation**
  * Added comprehensive Windows installation documentation including setup instructions and PATH configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->