### PR TITLE
Adaptive cache, multi-sub search, URL handling, clickable links

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,3 +42,16 @@ release:
   github:
     owner: ProgenyAlpha
     name: reddit-lurker
+
+brews:
+  - repository:
+      owner: ProgenyAlpha
+      name: homebrew-tap
+    name: lurk
+    homepage: "https://github.com/ProgenyAlpha/reddit-lurker"
+    description: "Reddit reader for LLMs — full comment trees, 77% fewer tokens"
+    license: "MIT"
+    install: |
+      bin.install "lurk"
+    test: |
+      assert_match "lurk v", shell_output("#{bin}/lurk version 2>&1")

--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
 ```
-  ██████╗ ███████╗██████╗ ██████╗ ██╗████████╗
-  ██╔══██╗██╔════╝██╔══██╗██╔══██╗██║╚══██╔══╝
-  ██████╔╝█████╗  ██║  ██║██║  ██║██║   ██║
-  ██╔══██╗██╔══╝  ██║  ██║██║  ██║██║   ██║
-  ██║  ██║███████╗██████╔╝██████╔╝██║   ██║
-  ╚═╝  ╚═╝╚══════╝╚═════╝ ╚═════╝ ╚═╝   ╚═╝
-  ██╗     ██╗   ██╗██████╗ ██╗  ██╗███████╗██████╗
-  ██║     ██║   ██║██╔══██╗██║ ██╔╝██╔════╝██╔══██╗
-  ██║     ██║   ██║██████╔╝█████╔╝ █████╗  ██████╔╝
-  ██║     ██║   ██║██╔══██╗██╔═██╗ ██╔══╝  ██╔══██╗
-  ███████╗╚██████╔╝██║  ██║██║  ██╗███████╗██║  ██║
-  ╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝
+  ██╗     ██╗   ██╗██████╗ ██╗  ██╗
+  ██║     ██║   ██║██╔══██╗██║ ██╔╝
+  ██║     ██║   ██║██████╔╝█████╔╝
+  ██║     ██║   ██║██╔══██╗██╔═██╗
+  ███████╗╚██████╔╝██║  ██║██║  ██╗
+  ╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝
 ```
 
 <p align="center">
@@ -20,93 +14,109 @@
   <a href="https://github.com/ProgenyAlpha/reddit-lurker"><img src="https://img.shields.io/badge/platform-linux%20%7C%20macOS%20%7C%20windows-lightgrey" alt="Platform"></a>
 </p>
 
-> Full Reddit threads for Claude. No keys. No OAuth. No missing replies.
+> Every comment. Every reply. 77% fewer tokens.
 
-Reddit killed self-serve API keys in November 2025. Now if you want an LLM to analyze a Reddit thread, your options are:
+An 800-comment Reddit thread costs ~120K tokens as raw JSON. Lurk delivers the same thread — full depth, every expanded reply — in ~31K tokens. That's not a rounding error. That's the difference between blowing your context window and having room to actually think about what you read.
 
-- Copy/paste (destroys structure)
-- Screenshot (loses half the replies)
-- Print to PDF (good luck)
-- Use an existing Reddit MCP that silently ignores "+47 more replies"
-
-The best parts of Reddit are buried 4-5 replies deep. The correction. The real answer. The "actually you're wrong and here's why" that saves you hours. Most tools never fetch them.
-
-**Reddit Lurker does.**
-
-It expands every collapsed reply. Resolves every `kind: more`. Reconstructs the full comment tree. Paste a Reddit URL and Claude gets the entire conversation. Works with any LLM that can consume structured text.
+Most Reddit MCP servers fetch the top-level comments and call it a day. The best parts of Reddit are buried 4-5 replies deep — the correction, the real answer, the "actually you're wrong and here's why" that saves you hours. Lurk expands every collapsed branch, resolves every `+N more replies` placeholder, and reconstructs the full comment tree. Then it compresses everything into a compact notation that's purpose-built for LLMs.
 
 ```
-Post: "I gave Claude the one thing it was missing: memory"
-  164 comments fetched
-  Max depth: 5
-  Collapsed branches expanded: all
-  Authentication required: none
+Post: "Finally We have the best agentic AI at home"
+ +-- Comment (180 pts)
+ |   +-- Reply (46 pts)
+ |   |   +-- Reply (34 pts)
+ |   |       +-- Reply (29 pts)
+ |   |           +-- Reply (8 pts)
+ |   |               +-- Reply (20 pts)           <-- most tools stop here
+ |   |                   +-- Reply (2 pts)
+ |   |                       +-- Reply (4 pts)
+ |   |                           +-- Reply (1 pt)
+ |   |                               +-- Reply (2 pts)  <-- lurk gets this
+ +-- Comment (82 pts)
+     +-- Reply (45 pts)
+         +-- Reply ...
 ```
 
+**104 of 109 comments. 10 levels deep. One API call.**
+
+## How Token Savings Work
+
+Lurk doesn't just fetch more data — it sends less of it. The Go binary does all the heavy lifting before tokens ever hit your model:
+
+1. **Fetch** — Hits Reddit's JSON endpoints, recursively expands every collapsed `more` placeholder
+2. **Extract** — Strips the 50+ unused fields per comment (gildings, awards, flair, metadata) down to 5-6 that matter
+3. **Compress** — Formats into compact tab-delimited notation: `d0 180 Recent-Success-1520 If you can host Kimi 2.5...`
+
+The result:
+
+| Format | ~Tokens for 109-comment thread |
+|--------|-------------------------------|
+| Raw Reddit JSON | ~12,000 |
+| Markdown | ~5,200 |
+| **Lurk compact** | **~3,050** |
+
+**77% fewer tokens than JSON. 42% fewer than markdown.** Same data, same structure, same depth. Claude never touches raw Reddit data — it gets exactly what it needs, already compressed.
+
+### Smart Comment Limiting
+
+Threads with 200+ comments get a preview first instead of dumping everything:
+
 ```
-Post
- +-- Comment (74 pts)
- |   +-- Reply (26 pts)
- |   |   +-- Reply (2 pts)
- |   +-- Reply (6 pts)
- |       +-- Reply (13 pts)        <-- most tools stop here
- |           +-- Reply (21 pts)
- |               +-- Reply (7 pts)
- |                   +-- Reply (1 pt)   <-- Lurker gets this
- +-- Comment (16 pts)
-     +-- Reply (20 pts)
-         +-- Reply (8 pts)
-             +-- Reply (1 pt)
+#post   r/ClaudeAI   u/poster   422pts   93%   805cmt   2026-01-28
+Finally We have the best agentic AI at home
+
+#comments   461
+d0  180  Recent-Success-1520  If you can host Kimi 2.5...
+...
+
+#warning   805 total comments, showing 461. Use limit=N for top N by score, or limit=0 for all (~31K tokens).
 ```
 
-Most tools stop at depth 1 or 2. Lurker reconstructs the entire tree.
+Claude sees the warning and decides whether to fetch everything or grab the top 50 by score. No surprise 31K-token dumps.
 
 ## What You Get
 
-- Full comment trees at any depth
-- Collapsed threads automatically expanded
-- Cross-posts traced back to the original
-- Galleries, video, media URLs extracted
-- 15-minute cache (same thread twice = instant)
-- 74-79% fewer tokens than raw JSON output
-- Single Go binary, zero dependencies
-- Read-only by design
-
-## Why Not Use Reddit's Official API?
-
-- Requires approval under the Responsible Builder Policy (self-serve keys no longer available)
-- Adds OAuth complexity and token management for what should be a read-only operation
-- Keys can expire mid-workflow
-
-Reddit still serves full JSON on every public page. Lurker uses that. No signup, no approval wait, no tokens to rotate. Respects Reddit's unauthenticated rate limits (10 req/min) with automatic retry and backoff.
-
-**Note:** Lurker only works with public subreddits and posts. Private and restricted subreddits require authentication, which Lurker does not support at this time.
+- **Full comment trees** at any depth — every collapsed branch expanded
+- **77% token savings** vs raw JSON, 42% vs markdown
+- **Smart limiting** — large threads preview first, expand on demand
+- **Adaptive caching** — new feeds: 2min, hot: 5min, threads: 10min, top: 30min, 50MB LRU cap
+- **Multi-subreddit search** — comma-separated subs, parallel fetch, deduped results
+- **OAuth support** — optional `lurk auth` for 6x rate limits (60 req/min vs 10)
+- **All URL formats** — reddit.com, old.reddit.com, new.reddit.com, np.reddit.com, redd.it short links, m.reddit.com, amp.reddit.com
+- **Cross-posts** traced to the original
+- **Galleries, video, media URLs** extracted as clickable links
+- **Single Go binary**, zero runtime dependencies
+- **Read-only by design** — no write operations, no account access
 
 ## Install
 
-### Zero-Dependency Install
+### One-Line Install (Recommended)
 
+**Linux / macOS:**
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ProgenyAlpha/reddit-lurker/master/install.sh | bash
 ```
 
-No Node. No Go. No nothing. Downloads the binary for your platform and walks you through editor setup. Supports Claude Code, Cursor, Windsurf, VS Code, Cline, and Zed. Works on Linux and macOS.
-
-### Windows Install
-
+**Windows (PowerShell):**
 ```powershell
 irm https://raw.githubusercontent.com/ProgenyAlpha/reddit-lurker/master/install.ps1 | iex
 ```
 
-Same interactive setup, installs to `%LOCALAPPDATA%\lurk` and adds it to your PATH.
+No Node. No Go. No nothing. Downloads the binary for your platform and walks you through editor setup. Supports Claude Code, Cursor, Windsurf, VS Code (Copilot), Cline, and Zed.
 
-### Node Install
+### Homebrew
+
+```bash
+brew install ProgenyAlpha/tap/lurk
+```
+
+### npx
 
 ```bash
 npx reddit-lurker
 ```
 
-If you already have Node/npm. Same result, different delivery truck.
+If you already have Node/npm. Same binary, different delivery truck.
 
 ### Go Install
 
@@ -114,7 +124,7 @@ If you already have Node/npm. Same result, different delivery truck.
 go install github.com/ProgenyAlpha/reddit-lurker@latest
 ```
 
-Builds from source. Requires [Go 1.24+](https://go.dev/dl/). Run `./install.sh` afterward for skill/MCP configuration.
+Builds from source. Requires [Go 1.24+](https://go.dev/dl/). Run `./install.sh` afterward for editor configuration.
 
 ### From Source
 
@@ -135,7 +145,7 @@ The installer walks you through editor selection and integration mode.
 | Claude Code | `~/.claude.json` or `~/.claude/skills/reddit/` | `mcpServers` |
 | Cursor | `~/.cursor/mcp.json` | `mcpServers` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers` |
-| VS Code | `~/.config/Code/User/mcp.json` (Linux) / `~/Library/.../Code/User/mcp.json` (macOS) | `servers` |
+| VS Code (Copilot) | `~/.config/Code/User/mcp.json` (Linux) / `~/Library/.../Code/User/mcp.json` (macOS) | `servers` |
 | Cline | VS Code globalStorage (auto-detected) | `mcpServers` |
 | Zed | `~/.config/zed/settings.json` | `context_servers` |
 
@@ -143,7 +153,7 @@ Claude Code also supports a **Skill** mode (~20 tokens overhead vs ~438 for MCP)
 
 ### Manual Configuration
 
-If you installed the binary yourself, add lurk to your editor's MCP config:
+Add lurk to your editor's MCP config:
 
 **Claude Code, Cursor, Windsurf, Cline:**
 ```json
@@ -181,30 +191,26 @@ If you installed the binary yourself, add lurk to your editor's MCP config:
 }
 ```
 
-## Updates
+## OAuth (Optional)
 
-Lurk checks for new versions once every 24 hours (background, non-blocking, 3-second timeout). If a newer release exists, you'll see a one-line notice after your command finishes.
-
-```bash
-lurk update              # Download and install latest
-lurk update --check      # Check only, don't install
-```
-
-If you installed via npm, brew, or `go install`, `lurk update` will detect that and tell you to use your package manager instead.
-
-### Disable Update Checks
-
-If you don't want any phone-home behavior:
+Lurk works without any authentication. But if you want 6x the rate limit (60 req/min instead of 10):
 
 ```bash
-# Option 1: environment variable
-export LURK_NO_UPDATE_CHECK=1
-
-# Option 2: config file
-mkdir -p ~/.config/lurk && echo "disabled" > ~/.config/lurk/no-update-check
+lurk auth
 ```
 
-This only disables the background check. `lurk update` still works manually.
+This opens Reddit's app creation page, walks you through the 5-minute setup, tests your credentials, and saves them. One-time process. Lurk handles token refresh automatically.
+
+```bash
+lurk auth --status   # Check if credentials are configured
+lurk auth --clear    # Remove saved credentials
+```
+
+You can also set credentials via environment variables:
+```bash
+export LURK_CLIENT_ID=your_client_id
+export LURK_CLIENT_SECRET=your_client_secret
+```
 
 ## Usage
 
@@ -212,20 +218,17 @@ Just talk to Claude naturally:
 
 - *"Read this thread"* + paste a Reddit URL
 - *"What's trending on r/ClaudeAI?"*
-- *"What's r/selfhosted arguing about today?"*
+- *"Search r/selfhosted,r/homelab for 'ZFS backup'"*
 - *"What has u/spez been up to?"*
 
 Claude handles the rest. No commands to memorize.
 
 ## Real Example
 
-Here's what Lurker actually outputs for a [109-comment r/LocalLLM thread](https://www.reddit.com/r/LocalLLM/comments/1qp880l/finally_we_have_the_best_agentic_ai_at_home/) about running Kimi K2.5 at home.
+Here's what lurk actually outputs for a [109-comment r/LocalLLM thread](https://www.reddit.com/r/LocalLLM/comments/1qp880l/finally_we_have_the_best_agentic_ai_at_home/) about running Kimi K2.5 at home.
 
-**What most tools give Claude:**
+**What most tools give your LLM:**
 ```
-# Finally We have the best agentic AI at home
-u/moks4tda | 422 pts | r/LocalLLM
-
 u/Recent-Success-1520 (180 pts)
   If you can host Kimi 2.5 1T+ model at home then it tells
   me you have a really big home
@@ -239,7 +242,7 @@ u/rookan (60 pts)
 ... 12 top-level comments, no replies
 ```
 
-**What Lurker gives Claude (compact notation):**
+**What lurk gives your LLM:**
 ```
 #post	r/LocalLLM	u/moks4tda	422pts	93%	109cmt	2026-01-28
 Finally We have the best agentic AI at home
@@ -249,7 +252,7 @@ d0	180	Recent-Success-1520	If you can host Kimi 2.5 1T+ model at home...
 d1	46	HenkPoley	Apparently it's a native 4 bit weights. So "only" 640 GB needed...
 d2	34	TechnicalGeologist99	Sorry...you're going to run that model on RAM?
 d3	29	HenkPoley	24 tokens per second on 2x 512GB Max Studio M3 Ultra
-d4	8	doradus_novae	See you tomorrow when it answers your question 😆
+d4	8	doradus_novae	See you tomorrow when it answers your question
 d5	20	Scrubbingbubblz	You are over exaggerating. 24 tokens per second...
 d6	2	Infinite100p	But what is the prompt processing speed?
 d7	4	Miserable-Dare5090	It's GPU inference, on two m3 ultras over TB5...
@@ -262,81 +265,78 @@ d0	27	keypa_	"at home" we probably don't have the same home...
 ...
 ```
 
-**104 of 109 comments loaded. 10 levels deep.** The 5 missing comments are deleted/removed posts that Reddit still counts but no longer serves content for. Lurker fetched everything Reddit was willing to return.
-
-The best stuff — hardware specs, cost breakdowns, the debate about whether 24 tok/s is actually useful for agentic workflows — is all buried at depth 3-9. Most tools never see it.
-
-**Search works too.** Here's `lurk search "reddit MCP" --sub ClaudeAI --limit 5`:
-
-```
-#search	"reddit MCP"	ClaudeAI	5
-1	237pts	58cmt	r/ClaudeAI	u/karanb192	Reddit MCP just hit the Anthropic Directory
-2	2228pts	311cmt	r/ClaudeAI	u/JokeGold5455	Claude Code is a Beast – Tips from 6 Months of Hardcore Use
-3	67pts	23cmt	r/ClaudeAI	u/karanb192	Built an MCP server for Claude Desktop to browse Reddit in real-time
-4	0pts	7cmt	r/ClaudeAI	u/New-Requirement-3742	Open Sourcing my Reddit MCP Server (TypeScript + Apify)
-5	1pts	1cmt	r/ClaudeAI	u/hurrah-dev	I built an MCP server for the Reddit Ads API
-```
-
-Result #1 is the most popular Reddit MCP on the Anthropic Directory. In its comments, a user asks:
-
-> *"I see that it only extracts a few top level comments right? ... when I need summarization of comments I need all of them, not just a few top level."*
-
-The developer's response: *"You can instruct the LLM to fetch all comments. It'll then go up to 100 comments."*
-
-Lurker pulled 104 comments from that thread on the first call — no "fetch more" instruction needed, no second request. That's already past their tool's ceiling, with full depth to boot.
+**104 of 109 comments. 10 levels deep. ~3,050 tokens.** The 5 missing are deleted posts Reddit still counts but no longer serves. The hardware specs, cost breakdowns, and the debate about whether 24 tok/s is actually useful for agentic workflows — all buried at depth 3-9 — most tools never see it.
 
 ## Benchmarks
 
-Real numbers from live Reddit threads (February 2025):
+Real numbers from live Reddit threads:
 
-| Thread | Comments fetched | Compact | Savings vs JSON | Fetch time |
-|--------|-----------------|---------|-----------------|------------|
-| 25-comment announcement | 25 / 25 (100%) | ~786 tokens | **74%** | ~0.3s |
-| 83-comment discussion | 80 / 83 (96%) | ~1,905 tokens | **79%** | ~1.4s |
-| 109-comment deep thread | 104 / 109 (95%) | ~3,050 tokens | **79%** | ~0.6s |
-| 348-comment mega thread | 340 / 348 (98%) | ~8,100 tokens | **77%** | ~3.2s |
-| 1,092-comment mega thread | 805 / 1,092 (74%) | ~34,500 tokens | **77%** | ~4.8s |
+| Thread | Comments fetched | Compact tokens | Savings vs JSON | Fetch time |
+|--------|-----------------|---------------|-----------------|------------|
+| 25-comment announcement | 25 / 25 (100%) | ~786 | **74%** | ~0.3s |
+| 83-comment discussion | 80 / 83 (96%) | ~1,905 | **79%** | ~1.4s |
+| 109-comment deep thread | 104 / 109 (95%) | ~3,050 | **79%** | ~0.6s |
+| 348-comment mega thread | 340 / 348 (98%) | ~8,100 | **77%** | ~3.2s |
+| 1,092-comment mega thread | 805 / 1,092 (74%) | ~34,500 | **77%** | ~4.8s |
 
-Compact notation saves 74-79% of tokens compared to raw JSON. Most threads return 95%+ of comments. Mega threads (1,000+) hit diminishing returns as Reddit counts deleted/removed comments in the total but no longer serves content for them — the ~287 "missing" comments in the 1,092 thread are ghosts. Lurker recursively expands every collapsed branch Reddit is willing to return.
+Most threads return 95%+ of comments. Mega threads (1,000+) hit diminishing returns because Reddit counts deleted/removed comments in the total but no longer serves them — the ~287 "missing" in the 1,092 thread are ghosts.
+
+## Updates
+
+Lurk checks for new versions once every 24 hours (background, non-blocking, 3-second timeout). If a newer release exists, you'll see a one-line notice after your command finishes.
+
+```bash
+lurk update              # Download and install latest
+lurk update --check      # Check only, don't install
+```
+
+If you installed via npm, brew, or `go install`, `lurk update` will detect that and tell you to use your package manager instead.
+
+### Disable Update Checks
+
+```bash
+# Option 1: environment variable
+export LURK_NO_UPDATE_CHECK=1
+
+# Option 2: config file
+mkdir -p ~/.config/lurk && echo "disabled" > ~/.config/lurk/no-update-check
+```
 
 ## Error Handling
 
-Lurker fails cleanly with a reason, never with raw HTTP dumps or Go stack traces:
+Lurk fails cleanly with a reason, never with raw HTTP dumps or stack traces:
 
 | Scenario | Error message |
 |----------|---------------|
 | Deleted/nonexistent thread | `not found — check the URL or subreddit name` |
-| Private/quarantined subreddit | `access denied — subreddit may be private (requires auth) or quarantined` |
-| Malformed URL | `not a valid thread URL — expected a link like reddit.com/r/sub/comments/id/title` |
+| Private/quarantined subreddit | `access denied — subreddit may be private or quarantined` |
+| Malformed URL | `not a valid thread URL — expected reddit.com/r/sub/comments/id/title` |
 | Reddit is down | `Reddit server error (HTTP 5xx) — Reddit may be down` |
-| No internet | `network error — check your internet connection` |
 | Rate limited | `rate limited — too many requests, try again shortly` |
-
-Deleted comments show as `[deleted]` in the output — Reddit still counts them in the comment total but no longer serves content for them.
 
 ## Limitations
 
-- **Public content only.** Private, restricted, and quarantined subreddits require OAuth, which Lurker doesn't support.
-- **Unauthenticated rate limit.** 10 requests/minute with automatic retry and exponential backoff. Large threads may take longer to fully expand.
-- **Deleted comments count but don't exist.** Reddit's comment count includes deleted and removed comments that no longer serve content. A "1,092-comment" thread may only have ~805 live comments. Lurker fetches everything Reddit returns — the gap is ghosts.
-- **No NSFW age gates.** Some NSFW subreddits gate content behind login even for public posts.
+- **Public content only** (without OAuth). Private and quarantined subreddits require `lurk auth`.
+- **Deleted comments are ghosts.** Reddit counts them in the total but no longer serves content. A "1,092-comment" thread may only have ~805 live comments.
+- **No media download.** Media URLs (images, video, galleries) are extracted as clickable links — not downloaded or embedded.
 
 ---
 
 ## Reference
 
-Everything below is for people who want the details. You don't need any of this to use Reddit Lurker.
+Everything below is for people who want the details.
 
-### Commands
-
-Claude runs these automatically, but you can also run them directly:
+### CLI Commands
 
 ```bash
 lurk thread "https://reddit.com/r/ClaudeAI/comments/..."   # Full thread + comments
 lurk subreddit ClaudeAI --sort top --time week --limit 10   # Browse
 lurk search "prompt engineering" --sub ClaudeAI --limit 5   # Search
+lurk search "ZFS" --sub selfhosted,homelab,datahoarder      # Multi-sub search
 lurk user spez --limit 5                                    # User activity
 lurk subreddit ClaudeAI --info                              # Subreddit metadata
+lurk auth                                                   # OAuth setup
+lurk update                                                 # Self-update
 ```
 
 ### Flags
@@ -346,76 +346,74 @@ lurk subreddit ClaudeAI --info                              # Subreddit metadata
 | `--sort` | hot, new, top, rising, controversial, relevance, comments | subreddit, search |
 | `--limit` | Max results (default 25) | subreddit, search, user |
 | `--time` | hour, day, week, month, year, all | subreddit, search |
-| `--sub` | Restrict search to one subreddit | search |
+| `--sub` | Restrict search to subreddit(s) — comma-separated for multi-sub | search |
 | `--after` | Pagination token for next page | subreddit, search |
 | `--info` | Subreddit metadata instead of posts | subreddit |
 | `--json` | Raw JSON output | all |
 | `--compact` | Compact notation (default in MCP mode) | all |
-| `--no-cache` | Skip the 15-minute cache | all |
+| `--no-cache` | Skip cache | all |
+
+### MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `lurk` | Read threads, browse subreddits, search posts, view user activity |
+| `lurk_info` | Get subreddit metadata (subscribers, active users, description) |
 
 ### Understanding Skill vs MCP
 
-Both modes use the same compact notation for output, so per-call token cost is identical. The real differences:
+Both modes use the same compact notation, so per-call token cost is identical. The differences:
 
-**Context overhead.** Every message you send, Claude also receives hidden instructions you don't see: tool definitions, context, rules. Skill adds ~20 tokens to this. MCP adds ~438 tokens. On subscription plans this is cached and free. On the API, you pay for it every message.
+**Context overhead.** Every message you send, Claude also receives hidden tool definitions. Skill adds ~20 tokens. MCP adds ~438 tokens. On subscription plans this is cached and free. On the API, you pay for it every message.
 
-**Caching.** MCP runs as a background server that stays alive between calls. Its 15-minute in-memory cache means hitting the same thread or subreddit twice is instant, no Reddit request. Skill starts a fresh process each call, so there's no cache between calls. You can adjust the TTL in `reddit/client.go` if you want it longer or shorter.
+**Caching.** MCP runs as a background server. Its adaptive in-memory cache means hitting the same thread or subreddit twice is instant. Skill starts a fresh process each call — no cross-call cache.
 
-**Permissions.** Skill works through Bash, so Claude needs permission to run shell commands. MCP is a native tool call that doesn't touch the shell. If you run Claude Code with Bash restricted or prefer fewer permission prompts, MCP works without it.
+**Permissions.** Skill works through Bash, so Claude needs shell permission. MCP is a native tool call. If you run with Bash restricted, MCP works without it.
 
 ### Compact Notation
 
-Both Skill and MCP use compact tab-delimited output designed for LLMs. Same data as markdown, ~42% fewer tokens (and ~77% fewer than raw JSON). Here's what Claude sees:
+Tab-delimited output designed for LLMs. `d0/d1/d2` = comment depth. Score before author. `+N` = collapsed comments not loaded. `#next` = pagination token. `#warning` = smart limit triggered.
 
-**Standard markdown (for comparison):**
-```markdown
-# Email and Claude
-**r/ClaudeAI** | u/BusyBea2 | 1 pts (57% upvoted) | 9 comments
-
-Have you figured out how to use Claude to manage your inbox?
-
-## Comments (3 loaded)
-
-**u/Ok-Version-8996** (6 pts)
-  I'm surprised gmail hasn't done this already
-
-  **u/BusyBea2** (3 pts)
-    i hear you, that's one of my first clean up things
-
-**u/turtle-toaster** (2 pts)
-  Claude Settings lets you connect your Gmail
 ```
-~180 tokens
-
-**Compact (what Claude actually gets):**
-```
-#post	r/ClaudeAI	u/BusyBea2	1pts	57%	9cmt	2026-02-23
+#post   r/ClaudeAI   u/BusyBea2   1pts   57%   9cmt   2026-02-23
 Email and Claude
 Have you figured out how to use Claude to manage your inbox?
 
-#comments	3
-d0	6	Ok-Version-8996	I'm surprised gmail hasn't done this already
-d1	3	BusyBea2	i hear you, that's one of my first clean up things
-d0	2	turtle-toaster	Claude Settings lets you connect your Gmail
+#comments   3
+d0   6   Ok-Version-8996   I'm surprised gmail hasn't done this already
+d1   3   BusyBea2   i hear you, that's one of my first clean up things
+d0   2   turtle-toaster   Claude Settings lets you connect your Gmail
 ```
-~105 tokens
 
-Same thread, same structure, **42% fewer tokens than markdown, 77% fewer than JSON.** `d0/d1/d2` = comment depth. Score before author. `+N` = collapsed comments. `#next` = pagination token.
+### Adaptive Cache
+
+| Content | TTL | Rationale |
+|---------|-----|-----------|
+| `/new` feeds | 2 min | Fresh content, stale quickly |
+| `/hot` feeds | 5 min | Changes moderately |
+| Threads & comments | 10 min | Stable once posted |
+| Search results | 10 min | Results shift slowly |
+| User profiles | 15 min | Rarely changes |
+| `/top` feeds | 30 min | Rankings are stable |
+
+50MB LRU cap with automatic eviction. OAuth-authenticated requests use `oauth.reddit.com` automatically.
 
 ### Under the Hood
 
-- Appends `.json` to any Reddit URL
+- Appends `.json` to any Reddit URL — no API keys needed for public content
 - Recursively walks comment trees to arbitrary depth
-- Fetches `/api/morechildren` to expand collapsed threads (batched, max 100 IDs)
-- Rate limited to 10 req/min (Reddit's unauthenticated limit)
+- Fetches `/api/morechildren` to expand collapsed threads (batched, max 100 IDs per request)
+- Unauthenticated: 10 req/min with burst allowance (100 tokens / 10-min window)
+- Authenticated: 60 req/min (OAuth client_credentials grant)
 - Retries 429/5xx with exponential backoff (3 attempts)
-- In-memory cache with 15-minute TTL
+- Resolves redd.it short links via HTTP redirect
+- Single static Go binary, cross-compiled for linux/darwin/windows amd64/arm64
 
 ### Build from Source
 
 ```bash
 make build                # Local binary
-make all                  # Cross-compile linux/darwin amd64/arm64
+make all                  # Cross-compile all platforms
 make install-skill        # Install to ~/.claude/skills/reddit/
 ```
 
@@ -423,12 +421,9 @@ make install-skill        # Install to ~/.claude/skills/reddit/
 
 ```bash
 rm -rf ~/.claude/skills/reddit                    # Remove skill
+lurk auth --clear                                 # Remove saved credentials
 # For MCP: edit ~/.claude.json, delete "lurk" from mcpServers
 ```
-
-## Project Status
-
-Actively maintained. Stable JSON parsing approach with minimal external dependencies. Read-only by design.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An 800-comment Reddit thread costs ~120K tokens as raw JSON. Lurk delivers the s
 
 Most Reddit MCP servers fetch the top-level comments and call it a day. The best parts of Reddit are buried 4-5 replies deep — the correction, the real answer, the "actually you're wrong and here's why" that saves you hours. Lurk expands every collapsed branch, resolves every `+N more replies` placeholder, and reconstructs the full comment tree. Then it compresses everything into a compact notation that's purpose-built for LLMs.
 
-```
+```text
 Post: "Finally We have the best agentic AI at home"
  +-- Comment (180 pts)
  |   +-- Reply (46 pts)
@@ -55,13 +55,13 @@ The result:
 | Markdown | ~5,200 |
 | **Lurk compact** | **~3,050** |
 
-**77% fewer tokens than JSON. 42% fewer than markdown.** Same data, same structure, same depth. Claude never touches raw Reddit data — it gets exactly what it needs, already compressed.
+**77% fewer tokens than JSON. 42% fewer than Markdown.** Same data, same structure, same depth. Claude never touches raw Reddit data — it gets exactly what it needs, already compressed.
 
 ### Smart Comment Limiting
 
 Threads with 200+ comments get a preview first instead of dumping everything:
 
-```
+```text
 #post   r/ClaudeAI   u/poster   422pts   93%   805cmt   2026-01-28
 Finally We have the best agentic AI at home
 
@@ -347,7 +347,7 @@ lurk update                                                 # Self-update
 | `--limit` | Max results (default 25) | subreddit, search, user |
 | `--time` | hour, day, week, month, year, all | subreddit, search |
 | `--sub` | Restrict search to subreddit(s) — comma-separated for multi-sub | search |
-| `--after` | Pagination token for next page | subreddit, search |
+| `--after` | Pagination token for next page | subreddit, search (single-sub only) |
 | `--info` | Subreddit metadata instead of posts | subreddit |
 | `--json` | Raw JSON output | all |
 | `--compact` | Compact notation (default in MCP mode) | all |
@@ -374,7 +374,7 @@ Both modes use the same compact notation, so per-call token cost is identical. T
 
 Tab-delimited output designed for LLMs. `d0/d1/d2` = comment depth. Score before author. `+N` = collapsed comments not loaded. `#next` = pagination token. `#warning` = smart limit triggered.
 
-```
+```text
 #post   r/ClaudeAI   u/BusyBea2   1pts   57%   9cmt   2026-02-23
 Email and Claude
 Have you figured out how to use Claude to manage your inbox?

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Post: "Finally We have the best agentic AI at home"
          +-- Reply ...
 ```
 
-**104 of 109 comments. 10 levels deep. One API call.**
+**104 of 109 comments. 10 levels deep. Fully automatic.**
 
 ## How Token Savings Work
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -25,7 +25,7 @@ func extractPositionalAndFlags(args []string) (positional string, flags []string
 				// For simplicity, always consume next as value if it exists
 				// Exception: flags like --json, --compact, --no-cache are boolean
 				flagName := strings.TrimLeft(arg, "-")
-				if flagName == "json" || flagName == "compact" || flagName == "no-cache" || flagName == "info" || flagName == "nsfw" {
+				if flagName == "json" || flagName == "compact" || flagName == "no-cache" || flagName == "info" {
 					continue
 				}
 				i++
@@ -46,7 +46,6 @@ func Thread(args []string) {
 	jsonOut := fs.Bool("json", false, "Output raw JSON")
 	compact := fs.Bool("compact", false, "Output compact notation")
 	noCache := fs.Bool("no-cache", false, "Skip cache")
-	nsfwFlag := fs.Bool("nsfw", false, "Allow NSFW content")
 	fs.Parse(flags)
 
 	if url == "" {
@@ -58,11 +57,6 @@ func Thread(args []string) {
 	thread, err := client.GetThread(url, *noCache)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
-	}
-
-	if thread.Post.Over18 && !*nsfwFlag {
-		fmt.Fprintln(os.Stderr, "This thread is NSFW. Use --nsfw to view.")
 		os.Exit(1)
 	}
 
@@ -89,7 +83,6 @@ func Subreddit(args []string) {
 	compact := fs.Bool("compact", false, "Output compact notation")
 	noCache := fs.Bool("no-cache", false, "Skip cache")
 	info := fs.Bool("info", false, "Show subreddit info instead of posts")
-	nsfwFlag := fs.Bool("nsfw", false, "Include NSFW posts")
 	fs.Parse(flags)
 
 	if name == "" {
@@ -121,10 +114,6 @@ func Subreddit(args []string) {
 		os.Exit(1)
 	}
 
-	if !*nsfwFlag {
-		posts = cliFilterSFW(posts)
-	}
-
 	switch {
 	case *jsonOut:
 		fmt.Println(format.ToJSON(posts))
@@ -149,7 +138,6 @@ func Search(args []string) {
 	jsonOut := fs.Bool("json", false, "Output raw JSON")
 	compact := fs.Bool("compact", false, "Output compact notation")
 	noCache := fs.Bool("no-cache", false, "Skip cache")
-	nsfwFlag := fs.Bool("nsfw", false, "Include NSFW posts")
 	fs.Parse(flags)
 
 	if query == "" {
@@ -162,10 +150,6 @@ func Search(args []string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
-	}
-
-	if !*nsfwFlag {
-		posts = cliFilterSFW(posts)
 	}
 
 	switch {
@@ -187,7 +171,6 @@ func User(args []string) {
 	jsonOut := fs.Bool("json", false, "Output raw JSON")
 	compact := fs.Bool("compact", false, "Output compact notation")
 	noCache := fs.Bool("no-cache", false, "Skip cache")
-	nsfwFlag := fs.Bool("nsfw", false, "Include NSFW posts")
 	fs.Parse(flags)
 
 	if username == "" {
@@ -202,10 +185,6 @@ func User(args []string) {
 		os.Exit(1)
 	}
 
-	if !*nsfwFlag {
-		posts = cliFilterSFW(posts)
-	}
-
 	switch {
 	case *jsonOut:
 		fmt.Println(format.ToJSON(map[string]any{
@@ -218,14 +197,4 @@ func User(args []string) {
 	default:
 		fmt.Print(format.FormatUser(info, posts, comments))
 	}
-}
-
-func cliFilterSFW(posts []*reddit.Post) []*reddit.Post {
-	filtered := make([]*reddit.Post, 0, len(posts))
-	for _, p := range posts {
-		if !p.Over18 {
-			filtered = append(filtered, p)
-		}
-	}
-	return filtered
 }

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -25,7 +25,7 @@ func extractPositionalAndFlags(args []string) (positional string, flags []string
 				// For simplicity, always consume next as value if it exists
 				// Exception: flags like --json, --compact, --no-cache are boolean
 				flagName := strings.TrimLeft(arg, "-")
-				if flagName == "json" || flagName == "compact" || flagName == "no-cache" || flagName == "info" {
+				if flagName == "json" || flagName == "compact" || flagName == "no-cache" || flagName == "info" || flagName == "nsfw" {
 					continue
 				}
 				i++
@@ -46,6 +46,7 @@ func Thread(args []string) {
 	jsonOut := fs.Bool("json", false, "Output raw JSON")
 	compact := fs.Bool("compact", false, "Output compact notation")
 	noCache := fs.Bool("no-cache", false, "Skip cache")
+	nsfwFlag := fs.Bool("nsfw", false, "Allow NSFW content")
 	fs.Parse(flags)
 
 	if url == "" {
@@ -57,6 +58,11 @@ func Thread(args []string) {
 	thread, err := client.GetThread(url, *noCache)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+
+	if thread.Post.Over18 && !*nsfwFlag {
+		fmt.Fprintln(os.Stderr, "This thread is NSFW. Use --nsfw to view.")
 		os.Exit(1)
 	}
 
@@ -83,6 +89,7 @@ func Subreddit(args []string) {
 	compact := fs.Bool("compact", false, "Output compact notation")
 	noCache := fs.Bool("no-cache", false, "Skip cache")
 	info := fs.Bool("info", false, "Show subreddit info instead of posts")
+	nsfwFlag := fs.Bool("nsfw", false, "Include NSFW posts")
 	fs.Parse(flags)
 
 	if name == "" {
@@ -114,6 +121,10 @@ func Subreddit(args []string) {
 		os.Exit(1)
 	}
 
+	if !*nsfwFlag {
+		posts = cliFilterSFW(posts)
+	}
+
 	switch {
 	case *jsonOut:
 		fmt.Println(format.ToJSON(posts))
@@ -130,7 +141,7 @@ func Search(args []string) {
 	query, flags := extractPositionalAndFlags(args)
 
 	fs := flag.NewFlagSet("search", flag.ExitOnError)
-	sub := fs.String("sub", "", "Restrict to subreddit")
+	sub := fs.String("sub", "", "Restrict to subreddit(s) (comma-separated)")
 	sort := fs.String("sort", "relevance", "Sort order (relevance, hot, top, new, comments)")
 	limit := fs.Int("limit", 25, "Number of results")
 	timeFilter := fs.String("time", "", "Time filter (hour, day, week, month, year, all)")
@@ -138,6 +149,7 @@ func Search(args []string) {
 	jsonOut := fs.Bool("json", false, "Output raw JSON")
 	compact := fs.Bool("compact", false, "Output compact notation")
 	noCache := fs.Bool("no-cache", false, "Skip cache")
+	nsfwFlag := fs.Bool("nsfw", false, "Include NSFW posts")
 	fs.Parse(flags)
 
 	if query == "" {
@@ -150,6 +162,10 @@ func Search(args []string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
+	}
+
+	if !*nsfwFlag {
+		posts = cliFilterSFW(posts)
 	}
 
 	switch {
@@ -171,6 +187,7 @@ func User(args []string) {
 	jsonOut := fs.Bool("json", false, "Output raw JSON")
 	compact := fs.Bool("compact", false, "Output compact notation")
 	noCache := fs.Bool("no-cache", false, "Skip cache")
+	nsfwFlag := fs.Bool("nsfw", false, "Include NSFW posts")
 	fs.Parse(flags)
 
 	if username == "" {
@@ -185,6 +202,10 @@ func User(args []string) {
 		os.Exit(1)
 	}
 
+	if !*nsfwFlag {
+		posts = cliFilterSFW(posts)
+	}
+
 	switch {
 	case *jsonOut:
 		fmt.Println(format.ToJSON(map[string]any{
@@ -197,4 +218,14 @@ func User(args []string) {
 	default:
 		fmt.Print(format.FormatUser(info, posts, comments))
 	}
+}
+
+func cliFilterSFW(posts []*reddit.Post) []*reddit.Post {
+	filtered := make([]*reddit.Post, 0, len(posts))
+	for _, p := range posts {
+		if !p.Over18 {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -63,7 +63,10 @@ Compact notation:
 			mcp.Description("Time filter: hour, day, week, month, year, all"),
 		),
 		mcp.WithString("sub",
-			mcp.Description("Restrict search to subreddit (search command only)"),
+			mcp.Description("Restrict search to subreddit(s) — comma-separated for multi-sub (search only)"),
+		),
+		mcp.WithBoolean("nsfw",
+			mcp.Description("Include NSFW content (default false)"),
 		),
 	)
 }
@@ -76,6 +79,7 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 		limit := req.GetInt("limit", 25)
 		timeFilter := req.GetString("time", "")
 		sub := req.GetString("sub", "")
+		nsfw := req.GetBool("nsfw", false)
 
 		if target == "" {
 			return mcp.NewToolResultError("target is required"), nil
@@ -90,6 +94,10 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 			thread, err := client.GetThreadShallow(target, false)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			if thread.Post.Over18 && !nsfw {
+				return mcp.NewToolResultError("this thread is NSFW — set nsfw=true to view"), nil
 			}
 
 			numComments := thread.Post.NumComments
@@ -125,6 +133,9 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
+			if !nsfw {
+				posts = filterSFW(posts)
+			}
 			return mcp.NewToolResultText(format.CompactPostList(posts, target, sort, after)), nil
 
 		case "search":
@@ -135,6 +146,9 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
+			if !nsfw {
+				posts = filterSFW(posts)
+			}
 			return mcp.NewToolResultText(format.CompactSearchResults(posts, target, sub, after)), nil
 
 		case "user":
@@ -142,12 +156,25 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
+			if !nsfw {
+				posts = filterSFW(posts)
+			}
 			return mcp.NewToolResultText(format.CompactUser(info, posts, comments)), nil
 
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("unknown command: %s", command)), nil
 		}
 	}
+}
+
+func filterSFW(posts []*reddit.Post) []*reddit.Post {
+	filtered := make([]*reddit.Post, 0, len(posts))
+	for _, p := range posts {
+		if !p.Over18 {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
 }
 
 func lurkInfoTool() mcp.Tool {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -65,9 +65,6 @@ Compact notation:
 		mcp.WithString("sub",
 			mcp.Description("Restrict search to subreddit(s) — comma-separated for multi-sub (search only)"),
 		),
-		mcp.WithBoolean("nsfw",
-			mcp.Description("Include NSFW content (default false)"),
-		),
 	)
 }
 
@@ -79,8 +76,6 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 		limit := req.GetInt("limit", 25)
 		timeFilter := req.GetString("time", "")
 		sub := req.GetString("sub", "")
-		nsfw := req.GetBool("nsfw", false)
-
 		if target == "" {
 			return mcp.NewToolResultError("target is required"), nil
 		}
@@ -94,10 +89,6 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 			thread, err := client.GetThreadShallow(target, false)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
-			}
-
-			if thread.Post.Over18 && !nsfw {
-				return mcp.NewToolResultError("this thread is NSFW — set nsfw=true to view"), nil
 			}
 
 			numComments := thread.Post.NumComments
@@ -133,9 +124,6 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
-			if !nsfw {
-				posts = filterSFW(posts)
-			}
 			return mcp.NewToolResultText(format.CompactPostList(posts, target, sort, after)), nil
 
 		case "search":
@@ -146,9 +134,6 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
-			if !nsfw {
-				posts = filterSFW(posts)
-			}
 			return mcp.NewToolResultText(format.CompactSearchResults(posts, target, sub, after)), nil
 
 		case "user":
@@ -156,25 +141,12 @@ func lurkHandler(client *reddit.Client) server.ToolHandlerFunc {
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
-			if !nsfw {
-				posts = filterSFW(posts)
-			}
 			return mcp.NewToolResultText(format.CompactUser(info, posts, comments)), nil
 
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("unknown command: %s", command)), nil
 		}
 	}
-}
-
-func filterSFW(posts []*reddit.Post) []*reddit.Post {
-	filtered := make([]*reddit.Post, 0, len(posts))
-	for _, p := range posts {
-		if !p.Over18 {
-			filtered = append(filtered, p)
-		}
-	}
-	return filtered
 }
 
 func lurkInfoTool() mcp.Tool {

--- a/format/compact.go
+++ b/format/compact.go
@@ -33,7 +33,7 @@ func CompactThread(t *reddit.Thread) string {
 		b.WriteString(truncate(p.SelfText, 500))
 		b.WriteByte('\n')
 		if p.MediaURL != "" {
-			fmt.Fprintf(&b, "#media\t%s\n", p.MediaURL)
+			fmt.Fprintf(&b, "#media\t[link](%s)\n", p.MediaURL)
 		}
 	} else {
 		url := p.MediaURL
@@ -43,7 +43,7 @@ func CompactThread(t *reddit.Thread) string {
 		b.WriteString(truncate(url, 500))
 		b.WriteByte('\n')
 		if p.MediaURL != "" && p.MediaURL != url {
-			fmt.Fprintf(&b, "#media\t%s\n", p.MediaURL)
+			fmt.Fprintf(&b, "#media\t[link](%s)\n", p.MediaURL)
 		}
 	}
 
@@ -69,7 +69,7 @@ func CompactPostList(posts []*reddit.Post, subName string, sort string, after st
 		if p == nil {
 			continue
 		}
-		fmt.Fprintf(&b, "%d\t%dpts\t%dcmt\t%s\tu/%s\t%s\t%s\n",
+		fmt.Fprintf(&b, "%d\t%dpts\t%dcmt\t%s\tu/%s\t%s\t[thread](https://www.reddit.com%s)\n",
 			i+1, p.Score, p.NumComments, formatTime(p.Created),
 			p.Author, truncate(p.Title, 80), p.Permalink)
 	}
@@ -99,7 +99,7 @@ func CompactSearchResults(posts []*reddit.Post, query string, sub string, after 
 		if p == nil {
 			continue
 		}
-		fmt.Fprintf(&b, "%d\t%dpts\t%dcmt\tr/%s\tu/%s\t%s\t%s\n",
+		fmt.Fprintf(&b, "%d\t%dpts\t%dcmt\tr/%s\tu/%s\t%s\t[thread](https://www.reddit.com%s)\n",
 			i+1, p.Score, p.NumComments, p.Subreddit,
 			p.Author, truncate(p.Title, 80), p.Permalink)
 	}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reddit-lurker",
   "version": "1.0.0",
-  "description": "Reddit reader for Claude Code — full comment trees, no auth, one binary",
+  "description": "Reddit reader for LLMs — full comment trees, 77% fewer tokens, one binary",
   "repository": {
     "type": "git",
     "url": "https://github.com/ProgenyAlpha/reddit-lurker"

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -63,12 +63,14 @@ async function extractZip(buffer, destDir) {
 }
 
 async function extractTarGz(buffer, destDir) {
-  // Write to temp file and extract with tar
   const tmp = path.join(os.tmpdir(), `lurk-${Date.now()}.tar.gz`);
   fs.writeFileSync(tmp, buffer);
   fs.mkdirSync(destDir, { recursive: true });
-  execSync(`tar xzf "${tmp}" -C "${destDir}"`, { stdio: "pipe" });
-  fs.unlinkSync(tmp);
+  try {
+    execSync(`tar xzf "${tmp}" -C "${destDir}"`, { stdio: "pipe" });
+  } finally {
+    if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+  }
 }
 
 async function main() {

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -16,7 +16,7 @@ function getPlatform() {
   const platform = process.platform;
   const arch = process.arch;
 
-  const osMap = { linux: "linux", darwin: "darwin" };
+  const osMap = { linux: "linux", darwin: "darwin", win32: "windows" };
   const archMap = { x64: "amd64", arm64: "arm64" };
 
   const goos = osMap[platform];
@@ -47,6 +47,14 @@ function download(url) {
   });
 }
 
+async function extractZip(buffer, destDir) {
+  const tmp = path.join(os.tmpdir(), `lurk-${Date.now()}.zip`);
+  fs.writeFileSync(tmp, buffer);
+  fs.mkdirSync(destDir, { recursive: true });
+  execSync(`powershell -Command "Expand-Archive -Force '${tmp}' '${destDir}'"`, { stdio: "pipe" });
+  fs.unlinkSync(tmp);
+}
+
 async function extractTarGz(buffer, destDir) {
   // Write to temp file and extract with tar
   const tmp = path.join(os.tmpdir(), `lurk-${Date.now()}.tar.gz`);
@@ -58,14 +66,21 @@ async function extractTarGz(buffer, destDir) {
 
 async function main() {
   const { goos, goarch } = getPlatform();
-  const archive = `lurk-${goos}-${goarch}.tar.gz`;
+  const isWindows = goos === "windows";
+  const archive = isWindows
+    ? `lurk-${goos}-${goarch}.zip`
+    : `lurk-${goos}-${goarch}.tar.gz`;
   const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${archive}`;
 
   console.log(`Downloading lurk v${VERSION} for ${goos}/${goarch}...`);
 
   try {
     const data = await download(url);
-    await extractTarGz(data, BIN_DIR);
+    if (isWindows) {
+      await extractZip(data, BIN_DIR);
+    } else {
+      await extractTarGz(data, BIN_DIR);
+    }
 
     // Make binary executable
     fs.chmodSync(BIN_PATH, 0o755);

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -51,8 +51,15 @@ async function extractZip(buffer, destDir) {
   const tmp = path.join(os.tmpdir(), `lurk-${Date.now()}.zip`);
   fs.writeFileSync(tmp, buffer);
   fs.mkdirSync(destDir, { recursive: true });
-  execSync(`powershell -Command "Expand-Archive -Force '${tmp}' '${destDir}'"`, { stdio: "pipe" });
-  fs.unlinkSync(tmp);
+  const esc = (p) => p.replace(/'/g, "''");
+  try {
+    execSync(
+      `powershell -NoProfile -NonInteractive -Command "Expand-Archive -Force -LiteralPath '${esc(tmp)}' -DestinationPath '${esc(destDir)}'"`,
+      { stdio: "pipe" }
+    );
+  } finally {
+    if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+  }
 }
 
 async function extractTarGz(buffer, destDir) {

--- a/reddit/client.go
+++ b/reddit/client.go
@@ -19,7 +19,7 @@ const (
 	userAgent      = "lurk/1.0 (github.com/ProgenyAlpha/reddit-lurker)"
 	maxRetries     = 3
 	retryDelay     = 2 * time.Second
-	cacheTTL       = 15 * time.Minute
+	maxCacheSize   = 50 * 1024 * 1024 // 50MB
 	// Reddit's unauthenticated limit is 10 req/min averaged over 10 minutes,
 	// which allows bursting. We use a 10-minute window with 100 tokens.
 	rateLimitWindow = 10 * time.Minute
@@ -31,6 +31,7 @@ type Client struct {
 	http      *http.Client
 	cache     map[string]*cacheEntry
 	cacheMu   sync.RWMutex
+	cacheSize int64
 	limiter   *rateLimiter
 	oauth     *oauthToken // nil when unauthenticated
 }
@@ -38,6 +39,29 @@ type Client struct {
 type cacheEntry struct {
 	data      []byte
 	expiresAt time.Time
+	size      int
+	lastUsed  time.Time
+	key       string
+}
+
+// cacheTTLFor returns an adaptive TTL based on URL pattern.
+func cacheTTLFor(key string) time.Duration {
+	switch {
+	case strings.Contains(key, "/new.json"), strings.Contains(key, "/new/"):
+		return 2 * time.Minute
+	case strings.Contains(key, "/hot.json"), strings.Contains(key, "/hot/"):
+		return 5 * time.Minute
+	case strings.Contains(key, "/top.json"), strings.Contains(key, "/top/"):
+		return 30 * time.Minute
+	case strings.Contains(key, "/comments/"), strings.Contains(key, "/api/morechildren"):
+		return 10 * time.Minute
+	case strings.Contains(key, "/user/"), strings.Contains(key, "/about.json"):
+		return 15 * time.Minute
+	case strings.Contains(key, "/search.json"):
+		return 10 * time.Minute
+	default:
+		return 15 * time.Minute
+	}
 }
 
 type rateLimiter struct {
@@ -386,21 +410,59 @@ func parseMoreChildrenComment(d map[string]any) *Comment {
 }
 
 func (c *Client) getCache(key string) []byte {
-	c.cacheMu.RLock()
-	defer c.cacheMu.RUnlock()
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
 	entry, ok := c.cache[key]
-	if !ok || time.Now().After(entry.expiresAt) {
+	if !ok {
 		return nil
 	}
+	if time.Now().After(entry.expiresAt) {
+		c.cacheSize -= int64(entry.size)
+		delete(c.cache, key)
+		return nil
+	}
+	entry.lastUsed = time.Now()
 	return entry.data
 }
 
 func (c *Client) setCache(key string, data []byte) {
 	c.cacheMu.Lock()
 	defer c.cacheMu.Unlock()
+
+	entrySize := len(data) + len(key) + 64
+	if int64(entrySize) > maxCacheSize {
+		return // don't cache entries larger than the limit
+	}
+
+	if old, ok := c.cache[key]; ok {
+		c.cacheSize -= int64(old.size)
+	}
+
+	for c.cacheSize+int64(entrySize) > maxCacheSize && len(c.cache) > 0 {
+		c.evictLRU()
+	}
+
+	now := time.Now()
 	c.cache[key] = &cacheEntry{
 		data:      data,
-		expiresAt: time.Now().Add(cacheTTL),
+		expiresAt: now.Add(cacheTTLFor(key)),
+		size:      entrySize,
+		lastUsed:  now,
+		key:       key,
+	}
+	c.cacheSize += int64(entrySize)
+}
+
+func (c *Client) evictLRU() {
+	var oldest *cacheEntry
+	for _, entry := range c.cache {
+		if oldest == nil || entry.lastUsed.Before(oldest.lastUsed) {
+			oldest = entry
+		}
+	}
+	if oldest != nil {
+		c.cacheSize -= int64(oldest.size)
+		delete(c.cache, oldest.key)
 	}
 }
 

--- a/reddit/search.go
+++ b/reddit/search.go
@@ -60,6 +60,9 @@ func (c *Client) Search(query string, sub string, sort SortOrder, limit int, tim
 }
 
 // searchMulti searches multiple subreddits in parallel and merges results by score.
+// Partial failures are tolerated: if some subreddits fail but others succeed, the
+// successful results are returned. Only returns an error if ALL subreddits fail.
+// Pagination is not supported for multi-sub queries — the after token is always empty.
 func (c *Client) searchMulti(query string, subs string, sortOrder SortOrder, limit int, timeFilter TimeFilter, noCache bool) ([]*Post, string, error) {
 	parts := strings.Split(subs, ",")
 	type result struct {

--- a/reddit/search.go
+++ b/reddit/search.go
@@ -3,11 +3,18 @@ package reddit
 import (
 	"fmt"
 	"net/url"
+	"strings"
+
+	gosort "sort"
 )
 
 // Search performs a Reddit search, optionally scoped to a subreddit.
-// Returns matching posts, the "after" pagination token, and any error.
+// Supports comma-separated subreddit names for parallel multi-sub search.
 func (c *Client) Search(query string, sub string, sort SortOrder, limit int, timeFilter TimeFilter, after string, noCache bool) ([]*Post, string, error) {
+	if strings.Contains(sub, ",") {
+		return c.searchMulti(query, sub, sort, limit, timeFilter, noCache)
+	}
+
 	if sort == "" {
 		sort = SortRelevance
 	}
@@ -50,4 +57,59 @@ func (c *Client) Search(query string, sub string, sort SortOrder, limit int, tim
 	}
 
 	return posts, listing.Data.After, nil
+}
+
+// searchMulti searches multiple subreddits in parallel and merges results by score.
+func (c *Client) searchMulti(query string, subs string, sortOrder SortOrder, limit int, timeFilter TimeFilter, noCache bool) ([]*Post, string, error) {
+	parts := strings.Split(subs, ",")
+	type result struct {
+		posts []*Post
+		err   error
+	}
+	ch := make(chan result, len(parts))
+
+	for _, s := range parts {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			ch <- result{}
+			continue
+		}
+		go func(sub string) {
+			posts, _, err := c.Search(query, sub, sortOrder, limit, timeFilter, "", noCache)
+			ch <- result{posts, err}
+		}(s)
+	}
+
+	seen := make(map[string]bool)
+	var merged []*Post
+	var firstErr error
+	for range parts {
+		r := <-ch
+		if r.err != nil {
+			if firstErr == nil {
+				firstErr = r.err
+			}
+			continue
+		}
+		for _, p := range r.posts {
+			if !seen[p.ID] {
+				seen[p.ID] = true
+				merged = append(merged, p)
+			}
+		}
+	}
+
+	if len(merged) == 0 && firstErr != nil {
+		return nil, "", firstErr
+	}
+
+	gosort.Slice(merged, func(i, j int) bool {
+		return merged[i].Score > merged[j].Score
+	})
+
+	if limit > 0 && len(merged) > limit {
+		merged = merged[:limit]
+	}
+
+	return merged, "", nil
 }

--- a/reddit/thread.go
+++ b/reddit/thread.go
@@ -11,7 +11,7 @@ import (
 
 // fetchThreadBase fetches and parses a thread without expansion.
 func (c *Client) fetchThreadBase(permalink string, noCache bool) (*Thread, error) {
-	permalink = extractPermalink(permalink)
+	permalink = c.extractPermalink(permalink)
 
 	if !strings.Contains(permalink, "/comments/") {
 		return nil, fmt.Errorf("not a valid thread URL — expected a link like reddit.com/r/sub/comments/id/title")
@@ -281,7 +281,7 @@ func expandMoreComments(client *Client, thread *Thread, noCache bool) int {
 }
 
 // extractPermalink strips a full Reddit URL down to the path.
-func extractPermalink(raw string) string {
+func (c *Client) extractPermalink(raw string) string {
 	raw = strings.TrimSpace(raw)
 
 	// Resolve redd.it short links (but not v.redd.it, i.redd.it, preview.redd.it CDN URLs)
@@ -289,7 +289,7 @@ func extractPermalink(raw string) string {
 		!strings.Contains(raw, "v.redd.it/") &&
 		!strings.Contains(raw, "i.redd.it/") &&
 		!strings.Contains(raw, "preview.redd.it/") {
-		if resolved := resolveRedditShortLink(raw); resolved != "" {
+		if resolved := c.resolveRedditShortLink(raw); resolved != "" {
 			raw = resolved
 		}
 	}
@@ -321,14 +321,16 @@ func extractPermalink(raw string) string {
 }
 
 // resolveRedditShortLink follows a redd.it redirect to get the full URL.
-func resolveRedditShortLink(shortURL string) string {
-	client := &http.Client{
+// Uses the shared client's transport but with redirect-following disabled.
+func (c *Client) resolveRedditShortLink(shortURL string) string {
+	redirectClient := &http.Client{
+		Transport: c.http.Transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 		Timeout: 5 * time.Second,
 	}
-	resp, err := client.Get(shortURL)
+	resp, err := redirectClient.Get(shortURL)
 	if err != nil {
 		return ""
 	}

--- a/reddit/thread.go
+++ b/reddit/thread.go
@@ -3,6 +3,7 @@ package reddit
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"time"
@@ -281,13 +282,35 @@ func expandMoreComments(client *Client, thread *Thread, noCache bool) int {
 
 // extractPermalink strips a full Reddit URL down to the path.
 func extractPermalink(raw string) string {
-	// Remove common Reddit domain prefixes
+	raw = strings.TrimSpace(raw)
+
+	// Resolve redd.it short links (but not v.redd.it, i.redd.it, preview.redd.it CDN URLs)
+	if strings.Contains(raw, "redd.it/") &&
+		!strings.Contains(raw, "v.redd.it/") &&
+		!strings.Contains(raw, "i.redd.it/") &&
+		!strings.Contains(raw, "preview.redd.it/") {
+		if resolved := resolveRedditShortLink(raw); resolved != "" {
+			raw = resolved
+		}
+	}
+
+	// All known Reddit domains — longer prefixes first to avoid partial matches
 	for _, prefix := range []string{
-		"https://www.reddit.com",
+		"https://np.reddit.com",
+		"https://new.reddit.com",
 		"https://old.reddit.com",
+		"https://www.reddit.com",
+		"https://m.reddit.com",
+		"https://amp.reddit.com",
+		"https://i.reddit.com",
 		"https://reddit.com",
-		"http://www.reddit.com",
+		"http://np.reddit.com",
+		"http://new.reddit.com",
 		"http://old.reddit.com",
+		"http://www.reddit.com",
+		"http://m.reddit.com",
+		"http://amp.reddit.com",
+		"http://i.reddit.com",
 		"http://reddit.com",
 	} {
 		if strings.HasPrefix(raw, prefix) {
@@ -295,6 +318,22 @@ func extractPermalink(raw string) string {
 		}
 	}
 	return raw
+}
+
+// resolveRedditShortLink follows a redd.it redirect to get the full URL.
+func resolveRedditShortLink(shortURL string) string {
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Get(shortURL)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	return resp.Header.Get("Location")
 }
 
 // parseComment recursively parses a comment tree from Reddit's API response.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,20 @@
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      clientId:
+        type: string
+        description: "Reddit OAuth client ID (optional — enables 6x rate limit)"
+      clientSecret:
+        type: string
+        description: "Reddit OAuth client secret (optional)"
+  commandFunction: |
+    (config) => ({
+      command: "npx",
+      args: ["-y", "reddit-lurker", "serve"],
+      env: {
+        ...(config.clientId ? { LURK_CLIENT_ID: config.clientId } : {}),
+        ...(config.clientSecret ? { LURK_CLIENT_SECRET: config.clientSecret } : {})
+      }
+    })


### PR DESCRIPTION
## Summary
- **Adaptive cache TTL** — pattern-based: new (2min), hot (5min), top (30min), threads (10min), search (10min), user (15min). 50MB size limit with LRU eviction.
- **Multi-subreddit search** — comma-separated sub names (`sub=ClaudeAI,LocalLLaMA`) search in parallel, dedup by post ID, merge by score
- **Extended URL formats** — np, new, m, amp, i.reddit.com + redd.it short link resolution via redirect follow
- **Clickable links** — media URLs and permalinks rendered as markdown links in compact output
- **README revamp** — rewritten to lead with token efficiency and full tree access
- **Homebrew tap** — goreleaser config for `brew install ProgenyAlpha/tap/lurk`
- **Smithery listing** — smithery.yaml for MCP directory
- **npm published** — `npx reddit-lurker` now live

## Test plan
- [ ] `go test ./...` passes
- [ ] `lurk search "AI" --sub ClaudeAI,LocalLLaMA` returns merged results
- [ ] `lurk thread "https://np.reddit.com/r/..."` resolves correctly
- [ ] `lurk thread "https://redd.it/abc123"` resolves short link