### PR TITLE
Fix batch data loss, rate limiter blocking, and uncapped multi-sub

### DIFF
--- a/reddit/client.go
+++ b/reddit/client.go
@@ -80,23 +80,27 @@ func newRateLimiter(maxPerMin int) *rateLimiter {
 }
 
 func (rl *rateLimiter) wait() {
-	rl.mu.Lock()
-	defer rl.mu.Unlock()
+	for {
+		rl.mu.Lock()
+		now := time.Now()
+		elapsed := now.Sub(rl.lastFill)
+		if elapsed >= rateLimitWindow {
+			rl.tokens = rl.max
+			rl.lastFill = now
+		}
 
-	now := time.Now()
-	elapsed := now.Sub(rl.lastFill)
-	if elapsed >= rateLimitWindow {
-		rl.tokens = rl.max
-		rl.lastFill = now
-	}
+		if rl.tokens > 0 {
+			rl.tokens--
+			rl.mu.Unlock()
+			return
+		}
 
-	if rl.tokens <= 0 {
+		// Out of tokens — compute wait, release lock, then sleep.
+		// Other goroutines can proceed if tokens refill while we wait.
 		wait := rateLimitWindow - elapsed
+		rl.mu.Unlock()
 		time.Sleep(wait)
-		rl.tokens = rl.max
-		rl.lastFill = time.Now()
 	}
-	rl.tokens--
 }
 
 // NewClient creates a new Reddit API client.

--- a/reddit/search.go
+++ b/reddit/search.go
@@ -65,6 +65,9 @@ func (c *Client) Search(query string, sub string, sort SortOrder, limit int, tim
 // Pagination is not supported for multi-sub queries — the after token is always empty.
 func (c *Client) searchMulti(query string, subs string, sortOrder SortOrder, limit int, timeFilter TimeFilter, noCache bool) ([]*Post, string, error) {
 	parts := strings.Split(subs, ",")
+	if len(parts) > 10 {
+		return nil, "", fmt.Errorf("too many subreddits (max 10, got %d)", len(parts))
+	}
 	type result struct {
 		posts []*Post
 		err   error

--- a/reddit/thread.go
+++ b/reddit/thread.go
@@ -188,9 +188,12 @@ func expandMoreComments(client *Client, thread *Thread, noCache bool) int {
 		allIDs = append(allIDs, m.moreIDs...)
 	}
 
+	// Track which IDs were successfully fetched so we only remove
+	// placeholders whose batches actually succeeded.
 	const batchSize = 100
 	var fetched []*Comment
 	var fetchedMore []*Comment // new "more" placeholders from expansion
+	fetchedIDs := make(map[string]bool)
 	for i := 0; i < len(allIDs); i += batchSize {
 		end := i + batchSize
 		if end > len(allIDs) {
@@ -199,6 +202,10 @@ func expandMoreComments(client *Client, thread *Thread, noCache bool) int {
 		batch, err := client.FetchMoreChildren(thread.Post.ID, allIDs[i:end], noCache)
 		if err != nil {
 			continue
+		}
+		// Mark these IDs as successfully fetched
+		for _, id := range allIDs[i:end] {
+			fetchedIDs[id] = true
 		}
 		for _, c := range batch {
 			if c != nil {
@@ -257,10 +264,21 @@ func expandMoreComments(client *Client, thread *Thread, noCache bool) int {
 		}
 	}
 
-	// Remove "more" placeholders that were expanded
-	// Process in reverse order to maintain stable indices
+	// Only remove "more" placeholders whose IDs were all successfully fetched.
+	// If a batch failed, keep the placeholder so it can be retried on the next pass.
+	// Process in reverse order to maintain stable indices.
 	for i := len(mores) - 1; i >= 0; i-- {
 		m := mores[i]
+		allFetched := true
+		for _, id := range m.moreIDs {
+			if !fetchedIDs[id] {
+				allFetched = false
+				break
+			}
+		}
+		if !allFetched {
+			continue
+		}
 		parent := *m.parent
 		if m.index < len(parent) {
 			newSlice := make([]*Comment, 0, len(parent)-1)


### PR DESCRIPTION
## Summary
- **Silent data loss**: `expandMoreComments` removed all "more" placeholders unconditionally, even when their batches failed. Now tracks which IDs were successfully fetched and only removes placeholders whose batches succeeded. Failed batches are retried on the next expansion pass.
- **Rate limiter blocking**: `wait()` held the mutex during `time.Sleep()`, blocking all concurrent goroutines for the entire sleep duration. Now releases the lock before sleeping.
- **Uncapped multi-sub**: `searchMulti` accepted arbitrary comma-separated lists with no limit. Capped at 10 subreddits.

## Test plan
- [ ] `go build ./...` passes
- [ ] Large thread expansion still works correctly
- [ ] Multi-sub search with >10 subs returns error